### PR TITLE
feat(cilium): regenerate hubble certs via cronjob to avoid TLS errors

### DIFF
--- a/charts/cilium/Chart.yaml
+++ b/charts/cilium/Chart.yaml
@@ -3,7 +3,7 @@ type: application
 name: cilium
 description: Deploy the Cilium CNI.
 icon: https://artifacthub.io/image/2ae85972-bf12-41a5-afb2-9b1147b2aa56
-version: 1.0.1
+version: 1.0.2
 appVersion: "1.18.3"
 dependencies:
   - repository: https://helm.cilium.io/

--- a/charts/cilium/values.yaml
+++ b/charts/cilium/values.yaml
@@ -87,6 +87,13 @@ cilium:
       enabled: true
     ui:
       enabled: true
+    tls:
+      auto:
+        # Use a CronJob to periodically regenerate Hubble certificates to
+        # avoid TLS errors caused by expired certificates.
+        method: cronJob
+        # Regenerate certificates monthly to stay well within the 1-year validity window.
+        schedule: "0 0 1 * *"
 
   # Enable BGP peering.
   # Docs: https://docs.cilium.io/en/latest/network/bgp-control-plane/bgp-control-plane/

--- a/deploy/clusters/prd-cph02/kube-system/cilium.yml
+++ b/deploy/clusters/prd-cph02/kube-system/cilium.yml
@@ -1,2 +1,2 @@
 chart: cilium
-tag: 1.0.0
+tag: 1.0.2


### PR DESCRIPTION
## Summary

- Switches Hubble TLS auto-generation from `method: helm` to `method: cronJob` with a monthly schedule (`0 0 1 * *`)
- This prevents TLS errors caused by expired Hubble certificates by rotating them well within the 1-year validity window
- Bumps chart version `1.0.1` → `1.0.2` and updates the `prd-cph02` cluster ref from `1.0.0` → `1.0.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)