### PR TITLE
feat(cph02): add llm.cph02.nicklasfrahm.dev to gateway

### DIFF
--- a/deploy/services/gateway/20-cluster-prd-cph02.yml
+++ b/deploy/services/gateway/20-cluster-prd-cph02.yml
@@ -7,5 +7,6 @@ gateway:
     - auth.nicklasfrahm.dev
     - kommodity.io
     - axon.nicklasfrahm.dev
+    - llm.cph02.nicklasfrahm.dev
   addresses:
     - value: 172.29.0.1


### PR DESCRIPTION
## Summary

- Add `llm.cph02.nicklasfrahm.dev` to the shared gateway hostnames for the `prd-cph02` cluster so the gateway accepts and TLS-terminates traffic for the kserve LLM endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)