### PR TITLE
feat(charts): add traefik umbrella chart

### DIFF
--- a/charts/traefik/Chart.yaml
+++ b/charts/traefik/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: traefik
+description: A Helm umbrella chart for Traefik components
+type: application
+version: 1.0.0

--- a/charts/traefik/Chart.yaml
+++ b/charts/traefik/Chart.yaml
@@ -3,3 +3,9 @@ name: traefik
 description: A Helm umbrella chart for Traefik components
 type: application
 version: 1.0.0
+
+dependencies:
+  - name: traefik
+    version: 39.0.7
+    repository: https://helm.traefik.io/traefik
+

--- a/charts/traefik/Chart.yaml
+++ b/charts/traefik/Chart.yaml
@@ -8,4 +8,5 @@ dependencies:
   - name: traefik
     version: 39.0.7
     repository: https://helm.traefik.io/traefik
+    condition: traefik.enabled
 

--- a/charts/traefik/README.md
+++ b/charts/traefik/README.md
@@ -1,0 +1,11 @@
+# Traefik Umbrella Chart
+
+This chart aggregates Traefik related components.
+
+## Usage
+
+To install the Traefik stack:
+
+```bash
+helm install traefik ./charts/traefik
+```

--- a/charts/traefik/values.yaml
+++ b/charts/traefik/values.yaml
@@ -1,0 +1,7 @@
+global:
+  domain: example.com
+
+traefik:
+  enabled: true
+
+# You can add other component overrides here


### PR DESCRIPTION
## Summary

- Add a new Helm umbrella chart for Traefik components in `charts/traefik/`.

## Test plan

- [x] Verify chart structure and files.
- [ ] Test installation with `helm install`.

💘 Generated with Crush