### PR TITLE
docs(vllm): update model id and name in setup guide

### DIFF
--- a/docs/vllm-setup-guide.md
+++ b/docs/vllm-setup-guide.md
@@ -26,8 +26,8 @@ To configure Crush to use your private vLLM instance, you need to edit your `cru
       "api_key": "dummy",
       "models": [
         {
-          "id": "cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
-          "name": "Gemma 4 26B A4B AWQ 4bit",
+          "id": "gemma-4-26b-a3b",
+          "name": "Gemma 4 MoE",
 
           // Maximum context window and default max tokens to allow for long conversations and tool calls.
           "context_window": 131072,
@@ -51,24 +51,24 @@ To configure Crush to use your private vLLM instance, you need to edit your `cru
   },
   "models": {
     "large": {
-      "model": "cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
+      "model": "gemma-4-26b-a3b",
       "provider": "vllm"
     },
     "small": {
-      "model": "cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
+      "model": "gemma-4-26b-a3b",
       "provider": "vllm"
     }
   },
   "recent_models": {
     "large": [
       {
-        "model": "cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
+        "model": "gemma-4-26b-a3b",
         "provider": "vllm"
       }
     ],
     "small": [
       {
-        "model": "cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
+        "model": "gemma-4-26b-a3b",
         "provider": "vllm"
       }
     ]
@@ -91,7 +91,7 @@ If you are using opencode, your configuration in `~/.config/opencode/opencode.js
         "baseURL": "https://llm.cph02.nicklasfrahm.dev/v1"
       },
       "models": {
-        "cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit": {
+        "gemma-4-26b-a3b": {
           "name": "Gemma 4 MoE",
           "limit": {
             "context": 131072,

--- a/docs/vllm-setup-guide.md
+++ b/docs/vllm-setup-guide.md
@@ -26,7 +26,7 @@ To configure Crush to use your private vLLM instance, you need to edit your `cru
       "api_key": "dummy",
       "models": [
         {
-          "id": "gemma-4-26b-a3b",
+          "id": "gemma-4-26b-a4b-it",
           "name": "Gemma 4 MoE",
 
           // Maximum context window and default max tokens to allow for long conversations and tool calls.
@@ -51,24 +51,24 @@ To configure Crush to use your private vLLM instance, you need to edit your `cru
   },
   "models": {
     "large": {
-      "model": "gemma-4-26b-a3b",
+      "model": "gemma-4-26b-a4b-it",
       "provider": "vllm"
     },
     "small": {
-      "model": "gemma-4-26b-a3b",
+      "model": "gemma-4-26b-a4b-it",
       "provider": "vllm"
     }
   },
   "recent_models": {
     "large": [
       {
-        "model": "gemma-4-26b-a3b",
+        "model": "gemma-4-26b-a4b-it",
         "provider": "vllm"
       }
     ],
     "small": [
       {
-        "model": "gemma-4-26b-a3b",
+        "model": "gemma-4-26b-a4b-it",
         "provider": "vllm"
       }
     ]
@@ -91,7 +91,7 @@ If you are using opencode, your configuration in `~/.config/opencode/opencode.js
         "baseURL": "https://llm.cph02.nicklasfrahm.dev/v1"
       },
       "models": {
-        "gemma-4-26b-a3b": {
+        "gemma-4-26b-a4b-it": {
           "name": "Gemma 4 MoE",
           "limit": {
             "context": 131072,


### PR DESCRIPTION

## Summary

- Update the model identifier to `gemma-4-26b-a4b-it` in the vLLM setup guide.
- Update the model name to `Gemma 4 MoE` in the vLLM setup guide.
- Applies changes to both Crush and opencode configuration examples.

## Test plan

- [x] Verified documentation changes manually via `view`.
- [x] Confirmed diff matches expected updates.


💘 Generated with Crush