### PR TITLE
fix(ci): skip image build for services without a Containerfile

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,7 +53,11 @@ jobs:
       - name: List services
         id: list
         run: |
-          services=$(find cmd -mindepth 1 -maxdepth 1 -type d | xargs -I{} basename {} | sort | jq -R . | jq -sc .)
+          services=$(
+            find cmd -mindepth 1 -maxdepth 1 -type d | xargs -I{} basename {} | sort | while read -r svc; do
+              [ -f "cmd/${svc}/Containerfile" ] || [ -f "Containerfile" ] && echo "$svc"
+            done | jq -R . | jq -sc .
+          )
           echo "matrix={\"service\":$services}" >> "$GITHUB_OUTPUT"
 
   publish:


### PR DESCRIPTION
## Summary

- Filter services in the `discover` phase to only include those with a `cmd/<service>/Containerfile` or a root `Containerfile`
- Prevents `docker/build-push-action` from failing with `open Containerfile: no such file or directory` for services that don't ship a container image

## Test plan

- [ ] Verify the `discover` job matrix excludes services without a Containerfile
- [ ] Confirm a service with a Containerfile still builds and pushes successfully on release

🤖 Generated with [Claude Code](https://claude.com/claude-code)