### PR TITLE
feat(vllm-bench): add token throughput benchmark CLI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
         run: |
           # Dynamically discover scopes from cmd/ and pkg/
           mapfile -t scopes < <(
-            printf 'ci\ndeps\ntools\ndocs\n'
+            printf 'ci\nconfig\ndeps\ntools\ndocs\n'
             find cmd -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort
             grep -rh --include='*.go' '^package ' pkg/ | awk '{print $2}' | grep -v '_test$' | sort -u
           )

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,7 +19,7 @@ linters:
         rules:
           json: camel
         overrides:
-          - path: cmd/vllm-bench/openai\.go
+          - pkg: cmd/vllm-bench/openai\.go
             rules:
               json: snake
     testpackage:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,13 +18,14 @@ linters:
       case:
         rules:
           json: camel
-        overrides:
-          - pkg: cmd/vllm-bench/openai\.go
-            rules:
-              json: snake
     testpackage:
       allow-packages:
         - main
+  exclusions:
+    rules:
+      - path: cmd/vllm-bench/openai\.go
+        linters:
+          - tagliatelle
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,14 @@ linters:
     - wsl
 
   settings:
+    tagliatelle:
+      case:
+        rules:
+          json: camel
+        overrides:
+          - path: cmd/vllm-bench/openai\.go
+            rules:
+              json: snake
     testpackage:
       allow-packages:
         - main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,21 @@ When calling a tool, emit it as a clean JSON block with no extra prose inside th
 
 ---
 
+## LLM DEPLOYMENT (Gemma 4 / vLLM)
+
+### Gemma 4 architecture notes
+
+- **5:1 local/global attention ratio**: only ~10 layers need a full-length KV cache; the other ~52 use a 4096-token sliding window. This makes 256K context affordable on a single RTX 3090 (24 GB) with `--max-num-seqs=1`.
+- **FLASH_ATTN is incompatible** with Gemma 4's head size — `ValueError: head_size not supported`. Do not set `--attention-backend=FLASH_ATTN`; let vLLM auto-select (falls back to TRITON_ATTN).
+- **Chat template**: do not hardcode `--chat-template=examples/tool_chat_template_gemma4.jinja`. The bundled vLLM template is stale and causes tool-call loops. Omit the flag so vLLM uses the model's own `chat_template.jinja` from the HuggingFace cache.
+- **HF cache invalidation**: after changing the model id or when tool-call behaviour regresses, clear the cache on the node so the updated tokenizer files are pulled: `rm -rf ~/.cache/huggingface/hub/models--cyankiwi--gemma-4-26B-A4B-it-AWQ-4bit`.
+
+### Backpressure middleware
+
+vLLM has a native scheduler queue — do not hold connections in middleware. The backpressure middleware should only 503 when `server_load_metrics >= MAX_CONCURRENT + MAX_QUEUE`; vLLM handles the actual waiting. `server_load_metrics` (populated by `--enable-server-load-tracking`) counts running + waiting requests.
+
+---
+
 ## GO SPECIFICS
 
 - **Idiomatic Go**: Follow table-driven tests, explicit error wrapping, and interface-first design.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,21 +104,6 @@ When calling a tool, emit it as a clean JSON block with no extra prose inside th
 
 ---
 
-## LLM DEPLOYMENT (Gemma 4 / vLLM)
-
-### Gemma 4 architecture notes
-
-- **5:1 local/global attention ratio**: only ~10 layers need a full-length KV cache; the other ~52 use a 4096-token sliding window. This makes 256K context affordable on a single RTX 3090 (24 GB) with `--max-num-seqs=1`.
-- **FLASH_ATTN is incompatible** with Gemma 4's head size — `ValueError: head_size not supported`. Do not set `--attention-backend=FLASH_ATTN`; let vLLM auto-select (falls back to TRITON_ATTN).
-- **Chat template**: do not hardcode `--chat-template=examples/tool_chat_template_gemma4.jinja`. The bundled vLLM template is stale and causes tool-call loops. Omit the flag so vLLM uses the model's own `chat_template.jinja` from the HuggingFace cache.
-- **HF cache invalidation**: after changing the model id or when tool-call behaviour regresses, clear the cache on the node so the updated tokenizer files are pulled: `rm -rf ~/.cache/huggingface/hub/models--cyankiwi--gemma-4-26B-A4B-it-AWQ-4bit`.
-
-### Backpressure middleware
-
-vLLM has a native scheduler queue — do not hold connections in middleware. The backpressure middleware should only 503 when `server_load_metrics >= MAX_CONCURRENT + MAX_QUEUE`; vLLM handles the actual waiting. `server_load_metrics` (populated by `--enable-server-load-tracking`) counts running + waiting requests.
-
----
-
 ## GO SPECIFICS
 
 - **Idiomatic Go**: Follow table-driven tests, explicit error wrapping, and interface-first design.
@@ -140,7 +125,7 @@ All commits must follow the **Conventional Commits** specification.
 - **Types**: `feat` (new feature), `fix` (bug fix)
 - **Scope**: Always required (e.g., `llm`, `ci`, `argocd`)
 - **Description**: Written in imperative mood ("add feature", not "added" or "adds")
-- **PR Description**: No test plan or attribution to Crush
+- **PR Description**: Never include a test plan section
 
 ### Examples
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,35 +1,5 @@
 # AI Agents Guidelines
 
-## MANDATORY PLANNING PHASE
-
-Before taking ANY action on a task, you MUST explicitly:
-
-1. Restate the problem in your own words.
-2. Identify edge cases and failure modes.
-3. Output a TODO list in this exact format:
-
-TODO:
-
-- [ ] <concrete, atomic step>
-- [ ] <concrete, atomic step>
-- [ ] <concrete, atomic step>
-      ...
-
-No tool calls are permitted until the TODO list is written.
-
-Rules for TODOs:
-
-- Each item must be a single, verifiable action (read file X, run command Y, edit function Z)
-- No vague steps like "figure out the problem" — be specific about what you will look at and why
-- Include an explicit verification step at the end (run tests, confirm output, check diff)
-- You may revise the TODO list mid-task if you discover new information, but you must re-emit the full updated list before continuing
-
-Only after writing the TODO list should you begin executing steps, checking them off as you go:
-
-- [x] <completed step>
-
----
-
 ## TOOL CALLING RULES
 
 1. **One tool call at a time.** Never batch multiple tool calls in a single turn. Wait for the result before proceeding.
@@ -74,33 +44,6 @@ When you encounter an error:
 - **Conservative Interpretation**: If a type, signature, or contract is ambiguous, state the ambiguity and pick the most conservative interpretation.
 - **Completeness**: Output complete, compilable code. No `// TODO` stubs unless explicitly asked.
 - **Error Handling**: Prefer returning errors over panicking.
-
----
-
-## OUTPUT FORMAT
-
-Structure your responses as follows:
-
-1. **TODO** (mandatory, before any tools)
-2. **Step execution** — for each step: intent sentence → tool call → observation
-3. **Summary** — what was done, what changed, what the user should know
-
-Keep prose concise. Prefer code and concrete facts over explanation. Do not apologize or hedge excessively.
-
----
-
-## TOOL CALL FORMAT
-
-When calling a tool, emit it as a clean JSON block with no extra prose inside the block:
-
-```json
-{
-  "name": "<tool_name>",
-  "parameters": {
-    "<key>": "<value>"
-  }
-}
-```
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,7 +125,7 @@ All commits must follow the **Conventional Commits** specification.
 - **Types**: `feat` (new feature), `fix` (bug fix)
 - **Scope**: Always required (e.g., `llm`, `ci`, `argocd`)
 - **Description**: Written in imperative mood ("add feature", not "added" or "adds")
-- **PR Description**: Never include a test plan section
+- **PR Description**: Never include a test plan section or attribution to any AI assistant (Crush, OpenCode, Claude, etc.)
 
 ### Examples
 

--- a/charts/llm/templates/clusterservingruntime.yaml
+++ b/charts/llm/templates/clusterservingruntime.yaml
@@ -36,6 +36,8 @@ spec:
               key: HF_TOKEN
         - name: PYTHONPATH
           value: "/opt/workspace/middlewares:${PYTHONPATH:-}"
+        - name: PYTORCH_ALLOC_CONF
+          value: "expandable_segments:True"
       volumeMounts:
         - name: middleware-volume
           mountPath: /opt/workspace/middlewares

--- a/charts/llm/templates/clusterservingruntime.yaml
+++ b/charts/llm/templates/clusterservingruntime.yaml
@@ -36,8 +36,6 @@ spec:
               key: HF_TOKEN
         - name: PYTHONPATH
           value: "/opt/workspace/middlewares:${PYTHONPATH:-}"
-        - name: PYTORCH_ALLOC_CONF
-          value: "expandable_segments:True"
       volumeMounts:
         - name: middleware-volume
           mountPath: /opt/workspace/middlewares

--- a/cmd/vllm-bench/bench.go
+++ b/cmd/vllm-bench/bench.go
@@ -22,21 +22,27 @@ func runBench(ctx context.Context, baseURL string, cfg config) {
 	benchCtx, cancel := context.WithTimeout(ctx, cfg.duration)
 	defer cancel()
 
-	st := &stats{}
-	var wg sync.WaitGroup
-	for i := range cfg.workers {
-		wg.Add(1)
+	stats := &stats{}
+
+	var waitGroup sync.WaitGroup
+
+	for workerIdx := range cfg.workers {
+		waitGroup.Add(1)
+
 		go func(id int) {
-			defer wg.Done()
-			benchWorker(benchCtx, id, baseURL, cfg, st)
-		}(i)
+			defer waitGroup.Done()
+
+			benchWorker(benchCtx, id, baseURL, cfg, stats)
+		}(workerIdx)
 	}
 
 	start := time.Now()
 	ticker := time.NewTicker(tickInterval)
+
 	defer ticker.Stop()
 
 	var throughputSamples []float64
+
 	var lastGenTok int64
 
 	for {
@@ -44,9 +50,9 @@ func runBench(ctx context.Context, baseURL string, cfg config) {
 		case <-ticker.C:
 			snap, _ := scrapeMetrics(baseURL + "/metrics")
 			elapsed := time.Since(start)
-			reqs := st.requests.Load()
-			gen := st.genTok.Load()
-			errs := st.errors.Load()
+			reqs := stats.requests.Load()
+			gen := stats.genTok.Load()
+			errs := stats.errors.Load()
 			deltaGen := gen - lastGenTok
 			lastGenTok = gen
 			tokPerSec := float64(deltaGen) / tickInterval.Seconds()
@@ -54,8 +60,8 @@ func runBench(ctx context.Context, baseURL string, cfg config) {
 			printTickLine(elapsed, reqs, errs, tokPerSec, float64(reqs)/elapsed.Seconds(), snap)
 
 		case <-benchCtx.Done():
-			wg.Wait()
-			printBenchSummary(start, st, throughputSamples)
+			waitGroup.Wait()
+			printBenchSummary(start, stats, throughputSamples)
 
 			return
 		}
@@ -69,7 +75,7 @@ func printTickLine(elapsed time.Duration, reqs, errs int64, tokPerSec, reqPerSec
 	)
 }
 
-func benchWorker(ctx context.Context, id int, baseURL string, cfg config, st *stats) {
+func benchWorker(ctx context.Context, workerID int, baseURL string, cfg config, stats *stats) {
 	for {
 		if ctx.Err() != nil {
 			return
@@ -89,25 +95,27 @@ func benchWorker(ctx context.Context, id int, baseURL string, cfg config, st *st
 		result, err := sendChatCompletion(ctx, cfg.client, baseURL, cfg.model, cfg.prompt, cfg.maxTokens)
 		if err != nil {
 			if ctx.Err() == nil {
-				log.Printf("worker %d: %v", id, err)
-				st.errors.Add(1)
+				log.Printf("worker %d: %v", workerID, err)
+				stats.errors.Add(1)
 			}
 
 			continue
 		}
-		st.requests.Add(1)
-		st.promptTok.Add(int64(result.promptTokens))
-		st.genTok.Add(int64(result.completionTokens))
-		st.latencyNs.Add(result.latency.Nanoseconds())
+
+		stats.requests.Add(1)
+
+		stats.promptTok.Add(int64(result.promptTokens))
+		stats.genTok.Add(int64(result.completionTokens))
+		stats.latencyNs.Add(result.latency.Nanoseconds())
 	}
 }
 
-func printBenchSummary(start time.Time, st *stats, samples []float64) {
+func printBenchSummary(start time.Time, stats *stats, samples []float64) {
 	elapsed := time.Since(start)
-	reqs := st.requests.Load()
-	gen := st.genTok.Load()
-	prompt := st.promptTok.Load()
-	errs := st.errors.Load()
+	reqs := stats.requests.Load()
+	gen := stats.genTok.Load()
+	prompt := stats.promptTok.Load()
+	errs := stats.errors.Load()
 
 	_, _ = fmt.Fprintf(os.Stdout, "\n─── summary ─────────────────────────────────────\n")
 	_, _ = fmt.Fprintf(os.Stdout, "duration:       %s\n", elapsed.Round(time.Millisecond))
@@ -115,7 +123,7 @@ func printBenchSummary(start time.Time, st *stats, samples []float64) {
 	_, _ = fmt.Fprintf(os.Stdout, "prompt tokens:  %d\n", prompt)
 	_, _ = fmt.Fprintf(os.Stdout, "gen tokens:     %d\n", gen)
 	_, _ = fmt.Fprintf(os.Stdout, "gen tok/s:      %.2f\n", float64(gen)/elapsed.Seconds())
-	_, _ = fmt.Fprintf(os.Stdout, "avg latency:    %s\n", avgLatency(st).Round(time.Millisecond))
+	_, _ = fmt.Fprintf(os.Stdout, "avg latency:    %s\n", avgLatency(stats).Round(time.Millisecond))
 
 	if len(samples) >= minChartSamples {
 		labels := timeLabels(len(samples), tickInterval)
@@ -124,22 +132,23 @@ func printBenchSummary(start time.Time, st *stats, samples []float64) {
 	}
 }
 
-func avgLatency(st *stats) time.Duration {
-	reqs := st.requests.Load()
+func avgLatency(stats *stats) time.Duration {
+	reqs := stats.requests.Load()
 	if reqs == 0 {
 		return 0
 	}
 
-	return time.Duration(st.latencyNs.Load() / reqs)
+	return time.Duration(stats.latencyNs.Load() / reqs)
 }
 
 // timeLabels builds evenly spaced x-axis labels for a chart of n samples at interval d.
 func timeLabels(n int, interval time.Duration) []string {
 	step := max(1, n/xAxisLabelDiv)
+
 	labels := make([]string, n)
-	for i := range n {
-		if i%step == 0 {
-			labels[i] = (time.Duration(i) * interval).String()
+	for labelIdx := range n {
+		if labelIdx%step == 0 {
+			labels[labelIdx] = (time.Duration(labelIdx) * interval).String()
 		}
 	}
 

--- a/cmd/vllm-bench/bench.go
+++ b/cmd/vllm-bench/bench.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -17,25 +18,24 @@ type stats struct {
 	latencyNs atomic.Int64
 }
 
-func runBench(ctx context.Context, baseURL string) {
-	benchCtx, cancel := context.WithTimeout(ctx, *flagDuration)
+func runBench(ctx context.Context, baseURL string, cfg config) {
+	benchCtx, cancel := context.WithTimeout(ctx, cfg.duration)
 	defer cancel()
 
 	st := &stats{}
 	var wg sync.WaitGroup
-	for i := range *flagWorkers {
+	for i := range cfg.workers {
 		wg.Add(1)
 		go func(id int) {
 			defer wg.Done()
-			benchWorker(benchCtx, id, baseURL, st)
+			benchWorker(benchCtx, id, baseURL, cfg, st)
 		}(i)
 	}
 
 	start := time.Now()
-	ticker := time.NewTicker(5 * time.Second)
+	ticker := time.NewTicker(tickInterval)
 	defer ticker.Stop()
 
-	// throughput samples for the end chart
 	var throughputSamples []float64
 	var lastGenTok int64
 
@@ -49,48 +49,50 @@ func runBench(ctx context.Context, baseURL string) {
 			errs := st.errors.Load()
 			deltaGen := gen - lastGenTok
 			lastGenTok = gen
-			tokPerSec := float64(deltaGen) / 5
+			tokPerSec := float64(deltaGen) / tickInterval.Seconds()
 			throughputSamples = append(throughputSamples, tokPerSec)
-			avgLat := avgLatency(st)
-			fmt.Printf("[%5s] requests=%-4d errors=%-3d gen_tok/s=%6.1f req/s=%4.2f avg_lat=%s running=%.0f waiting=%.0f\n",
-				elapsed.Round(time.Second),
-				reqs, errs,
-				tokPerSec,
-				float64(reqs)/elapsed.Seconds(),
-				avgLat.Round(time.Millisecond),
-				snap.running, snap.waiting,
-			)
+			printTickLine(elapsed, reqs, errs, tokPerSec, float64(reqs)/elapsed.Seconds(), snap)
 
 		case <-benchCtx.Done():
 			wg.Wait()
 			printBenchSummary(start, st, throughputSamples)
+
 			return
 		}
 	}
 }
 
-func benchWorker(ctx context.Context, id int, baseURL string, st *stats) {
+func printTickLine(elapsed time.Duration, reqs, errs int64, tokPerSec, reqPerSec float64, snap vllmSnapshot) {
+	_, _ = fmt.Fprintf(os.Stdout,
+		"[%5s] requests=%-4d errors=%-3d gen_tok/s=%6.1f req/s=%4.2f avg_lat=? running=%.0f waiting=%.0f\n",
+		elapsed.Round(time.Second), reqs, errs, tokPerSec, reqPerSec, snap.running, snap.waiting,
+	)
+}
+
+func benchWorker(ctx context.Context, id int, baseURL string, cfg config, st *stats) {
 	for {
 		if ctx.Err() != nil {
 			return
 		}
 
 		snap, err := scrapeMetrics(baseURL + "/metrics")
-		if err == nil && snap.waiting >= float64(*flagMaxQueue) {
+		if err == nil && snap.waiting >= float64(cfg.maxQueue) {
 			select {
 			case <-ctx.Done():
 				return
-			case <-time.After(500 * time.Millisecond):
+			case <-time.After(backoffDuration):
 			}
+
 			continue
 		}
 
-		result, err := sendChatCompletion(ctx, baseURL, *flagModel, *flagPrompt, *flagMaxTokens)
+		result, err := sendChatCompletion(ctx, cfg.client, baseURL, cfg.model, cfg.prompt, cfg.maxTokens)
 		if err != nil {
 			if ctx.Err() == nil {
 				log.Printf("worker %d: %v", id, err)
 				st.errors.Add(1)
 			}
+
 			continue
 		}
 		st.requests.Add(1)
@@ -107,19 +109,18 @@ func printBenchSummary(start time.Time, st *stats, samples []float64) {
 	prompt := st.promptTok.Load()
 	errs := st.errors.Load()
 
-	fmt.Printf("\n─── summary ─────────────────────────────────────\n")
-	fmt.Printf("duration:       %s\n", elapsed.Round(time.Millisecond))
-	fmt.Printf("requests:       %d  (errors: %d)\n", reqs, errs)
-	fmt.Printf("prompt tokens:  %d\n", prompt)
-	fmt.Printf("gen tokens:     %d\n", gen)
-	fmt.Printf("gen tok/s:      %.2f\n", float64(gen)/elapsed.Seconds())
-	fmt.Printf("avg latency:    %s\n", avgLatency(st).Round(time.Millisecond))
+	_, _ = fmt.Fprintf(os.Stdout, "\n─── summary ─────────────────────────────────────\n")
+	_, _ = fmt.Fprintf(os.Stdout, "duration:       %s\n", elapsed.Round(time.Millisecond))
+	_, _ = fmt.Fprintf(os.Stdout, "requests:       %d  (errors: %d)\n", reqs, errs)
+	_, _ = fmt.Fprintf(os.Stdout, "prompt tokens:  %d\n", prompt)
+	_, _ = fmt.Fprintf(os.Stdout, "gen tokens:     %d\n", gen)
+	_, _ = fmt.Fprintf(os.Stdout, "gen tok/s:      %.2f\n", float64(gen)/elapsed.Seconds())
+	_, _ = fmt.Fprintf(os.Stdout, "avg latency:    %s\n", avgLatency(st).Round(time.Millisecond))
 
-	if len(samples) >= 2 {
-		// x-axis: one label every ~10 samples or at most 10 labels
-		labels := timeLabels(len(samples), 5*time.Second)
-		fmt.Printf("\n")
-		fmt.Println(lineChart("Generation throughput (tok/s) over time", labels, samples, "tok/s"))
+	if len(samples) >= minChartSamples {
+		labels := timeLabels(len(samples), tickInterval)
+		_, _ = fmt.Fprintln(os.Stdout)
+		_, _ = fmt.Fprintln(os.Stdout, lineChart("Generation throughput (tok/s) over time", labels, samples, "tok/s"))
 	}
 }
 
@@ -128,17 +129,19 @@ func avgLatency(st *stats) time.Duration {
 	if reqs == 0 {
 		return 0
 	}
+
 	return time.Duration(st.latencyNs.Load() / reqs)
 }
 
 // timeLabels builds evenly spaced x-axis labels for a chart of n samples at interval d.
 func timeLabels(n int, interval time.Duration) []string {
-	step := max(1, n/8)
+	step := max(1, n/xAxisLabelDiv)
 	labels := make([]string, n)
 	for i := range n {
 		if i%step == 0 {
 			labels[i] = (time.Duration(i) * interval).String()
 		}
 	}
+
 	return labels
 }

--- a/cmd/vllm-bench/bench.go
+++ b/cmd/vllm-bench/bench.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type stats struct {
+	requests  atomic.Int64
+	promptTok atomic.Int64
+	genTok    atomic.Int64
+	errors    atomic.Int64
+	latencyNs atomic.Int64
+}
+
+func runBench(ctx context.Context, baseURL string) {
+	benchCtx, cancel := context.WithTimeout(ctx, *flagDuration)
+	defer cancel()
+
+	st := &stats{}
+	var wg sync.WaitGroup
+	for i := range *flagWorkers {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			benchWorker(benchCtx, id, baseURL, st)
+		}(i)
+	}
+
+	start := time.Now()
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	// throughput samples for the end chart
+	var throughputSamples []float64
+	var lastGenTok int64
+
+	for {
+		select {
+		case <-ticker.C:
+			snap, _ := scrapeMetrics(baseURL + "/metrics")
+			elapsed := time.Since(start)
+			reqs := st.requests.Load()
+			gen := st.genTok.Load()
+			errs := st.errors.Load()
+			deltaGen := gen - lastGenTok
+			lastGenTok = gen
+			tokPerSec := float64(deltaGen) / 5
+			throughputSamples = append(throughputSamples, tokPerSec)
+			avgLat := avgLatency(st)
+			fmt.Printf("[%5s] requests=%-4d errors=%-3d gen_tok/s=%6.1f req/s=%4.2f avg_lat=%s running=%.0f waiting=%.0f\n",
+				elapsed.Round(time.Second),
+				reqs, errs,
+				tokPerSec,
+				float64(reqs)/elapsed.Seconds(),
+				avgLat.Round(time.Millisecond),
+				snap.running, snap.waiting,
+			)
+
+		case <-benchCtx.Done():
+			wg.Wait()
+			printBenchSummary(start, st, throughputSamples)
+			return
+		}
+	}
+}
+
+func benchWorker(ctx context.Context, id int, baseURL string, st *stats) {
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+
+		snap, err := scrapeMetrics(baseURL + "/metrics")
+		if err == nil && snap.waiting >= float64(*flagMaxQueue) {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(500 * time.Millisecond):
+			}
+			continue
+		}
+
+		result, err := sendChatCompletion(ctx, baseURL, *flagModel, *flagPrompt, *flagMaxTokens)
+		if err != nil {
+			if ctx.Err() == nil {
+				log.Printf("worker %d: %v", id, err)
+				st.errors.Add(1)
+			}
+			continue
+		}
+		st.requests.Add(1)
+		st.promptTok.Add(int64(result.promptTokens))
+		st.genTok.Add(int64(result.completionTokens))
+		st.latencyNs.Add(result.latency.Nanoseconds())
+	}
+}
+
+func printBenchSummary(start time.Time, st *stats, samples []float64) {
+	elapsed := time.Since(start)
+	reqs := st.requests.Load()
+	gen := st.genTok.Load()
+	prompt := st.promptTok.Load()
+	errs := st.errors.Load()
+
+	fmt.Printf("\n─── summary ─────────────────────────────────────\n")
+	fmt.Printf("duration:       %s\n", elapsed.Round(time.Millisecond))
+	fmt.Printf("requests:       %d  (errors: %d)\n", reqs, errs)
+	fmt.Printf("prompt tokens:  %d\n", prompt)
+	fmt.Printf("gen tokens:     %d\n", gen)
+	fmt.Printf("gen tok/s:      %.2f\n", float64(gen)/elapsed.Seconds())
+	fmt.Printf("avg latency:    %s\n", avgLatency(st).Round(time.Millisecond))
+
+	if len(samples) >= 2 {
+		// x-axis: one label every ~10 samples or at most 10 labels
+		labels := timeLabels(len(samples), 5*time.Second)
+		fmt.Printf("\n")
+		fmt.Println(lineChart("Generation throughput (tok/s) over time", labels, samples, "tok/s"))
+	}
+}
+
+func avgLatency(st *stats) time.Duration {
+	reqs := st.requests.Load()
+	if reqs == 0 {
+		return 0
+	}
+	return time.Duration(st.latencyNs.Load() / reqs)
+}
+
+// timeLabels builds evenly spaced x-axis labels for a chart of n samples at interval d.
+func timeLabels(n int, interval time.Duration) []string {
+	step := max(1, n/8)
+	labels := make([]string, n)
+	for i := range n {
+		if i%step == 0 {
+			labels[i] = (time.Duration(i) * interval).String()
+		}
+	}
+	return labels
+}

--- a/cmd/vllm-bench/constants.go
+++ b/cmd/vllm-bench/constants.go
@@ -8,8 +8,8 @@ const (
 	defaultMaxTokens    = 512
 	defaultMaxQueue     = 3
 	defaultPort         = 18000
-	defaultSweepReqs    = 3
-	defaultSweepOutToks = 64
+	defaultSweepReqs    = 20
+	defaultSweepOutToks = 128
 
 	// Timing constants.
 	tickInterval    = 5 * time.Second
@@ -23,6 +23,10 @@ const (
 	minChartWidth   = 60
 	chartHeight     = 10
 	yAxisPadding    = 2
+
+	// Math constants.
+	halfDivisor  = 2
+	roundingHalf = 0.5
 
 	// Parsing constants.
 	minPrometheusFields = 2

--- a/cmd/vllm-bench/constants.go
+++ b/cmd/vllm-bench/constants.go
@@ -1,0 +1,34 @@
+package main
+
+import "time"
+
+const (
+	// Default flag values.
+	defaultDuration     = 2 * time.Minute
+	defaultMaxTokens    = 512
+	defaultMaxQueue     = 3
+	defaultPort         = 18000
+	defaultSweepReqs    = 3
+	defaultSweepOutToks = 64
+
+	// Timing constants.
+	tickInterval    = 5 * time.Second
+	backoffDuration = 500 * time.Millisecond
+	clientTimeout   = 15 * time.Minute
+	pfTimeout       = 30 * time.Second
+
+	// Chart constants.
+	minChartSamples = 2
+	xAxisLabelDiv   = 8
+	minChartWidth   = 60
+	chartHeight     = 10
+	yAxisPadding    = 2
+
+	// Parsing constants.
+	minPrometheusFields = 2
+
+	// Prompt padding constants.
+	tokensPerK      = 1024
+	paddingOverhead = 20
+	charsPerToken   = 3.5
+)

--- a/cmd/vllm-bench/main.go
+++ b/cmd/vllm-bench/main.go
@@ -153,7 +153,7 @@ func findPod(ctx context.Context, namespace, selector string) (string, error) {
 		Items []struct {
 			Metadata struct {
 				Name              string `json:"name"`
-				DeletionTimestamp string `json:"deletionTimestamp"` //nolint:tagliatelle // Kubernetes API uses camelCase
+				DeletionTimestamp string `json:"deletionTimestamp"`
 			} `json:"metadata"`
 		} `json:"items"`
 	}

--- a/cmd/vllm-bench/main.go
+++ b/cmd/vllm-bench/main.go
@@ -51,7 +51,7 @@ func parseFlags() config {
 	flag.IntVar(&cfg.workers, "workers", 1, "concurrent workers; each sends requests sequentially")
 	flag.StringVar(&cfg.namespace, "namespace", "llm", "kubernetes namespace")
 	flag.StringVar(&cfg.selector, "selector", defaultSelector, "pod label selector")
-	flag.StringVar(&cfg.model, "model", "gemma4-26b-a4b-it", "served model name")
+	flag.StringVar(&cfg.model, "model", "gemma-4-26b-a4b-it", "served model name")
 	flag.IntVar(&cfg.maxTokens, "max-tokens", defaultMaxTokens, "max completion tokens per request")
 	flag.IntVar(&cfg.maxQueue, "max-queue", defaultMaxQueue, "pause worker when vLLM waiting queue reaches this depth")
 	flag.IntVar(&cfg.port, "port", defaultPort, "local port for kubectl port-forward")

--- a/cmd/vllm-bench/main.go
+++ b/cmd/vllm-bench/main.go
@@ -6,15 +6,15 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"flag"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"os/exec"
 	"os/signal"
 	"syscall"
 	"time"
+
+	"github.com/spf13/cobra"
 )
 
 var (
@@ -23,8 +23,8 @@ var (
 )
 
 const (
-	defaultSelector = "serving.kserve.io/inferenceservice=llm"
-	defaultPrompt   = "Explain in detail how transformer attention mechanisms work in large language models."
+	defaultSelector  = "serving.kserve.io/inferenceservice=llm"
+	defaultPrompt    = "Explain in detail how transformer attention mechanisms work in large language models."
 	defaultSweepSizes = "1024,4096,16384,32768,65536,131072"
 )
 
@@ -38,77 +38,102 @@ type config struct {
 	maxQueue     int
 	port         int
 	prompt       string
-	sweep        bool
 	sweepSizes   string
 	sweepReqs    int
 	sweepOutToks int
 	client       *http.Client
 }
 
-func parseFlags() config {
-	var cfg config
-	flag.DurationVar(&cfg.duration, "duration", defaultDuration, "benchmark duration (standard mode)")
-	flag.IntVar(&cfg.workers, "workers", 1, "concurrent workers; each sends requests sequentially")
-	flag.StringVar(&cfg.namespace, "namespace", "llm", "kubernetes namespace")
-	flag.StringVar(&cfg.selector, "selector", defaultSelector, "pod label selector")
-	flag.StringVar(&cfg.model, "model", "gemma4-26b", "served model name")
-	flag.IntVar(&cfg.maxTokens, "max-tokens", defaultMaxTokens, "max completion tokens per request")
-	flag.IntVar(&cfg.maxQueue, "max-queue", defaultMaxQueue, "pause worker when vLLM waiting queue reaches this depth")
-	flag.IntVar(&cfg.port, "port", defaultPort, "local port for kubectl port-forward")
-	flag.StringVar(&cfg.prompt, "prompt", defaultPrompt, "prompt for standard mode")
-	flag.BoolVar(&cfg.sweep, "sweep", false, "sweep context sizes and plot results")
-	flag.StringVar(&cfg.sweepSizes, "sweep-sizes", defaultSweepSizes, "comma-separated input token targets for sweep mode")
-	flag.IntVar(&cfg.sweepReqs, "sweep-requests", defaultSweepReqs, "requests per context size in sweep mode (averaged)")
-	flag.IntVar(&cfg.sweepOutToks, "sweep-out-tokens", defaultSweepOutToks, "output tokens per request in sweep mode")
-	flag.Parse()
-
-	cfg.client = &http.Client{Timeout: clientTimeout}
-
-	return cfg
-}
-
 func main() {
-	err := run()
+	err := newRootCmd().Execute()
 	if err != nil {
-		log.Fatal(err)
+		os.Exit(1)
 	}
 }
 
-func run() error {
-	cfg := parseFlags()
+func newRootCmd() *cobra.Command {
+	var cfg config
+
+	root := &cobra.Command{
+		Use:   "vllm-bench",
+		Short: "Token throughput benchmark for vLLM deployments running in Kubernetes",
+	}
+
+	root.PersistentFlags().StringVar(&cfg.namespace, "namespace", "llm", "Kubernetes namespace")
+	root.PersistentFlags().StringVar(&cfg.selector, "selector", defaultSelector, "pod label selector")
+	root.PersistentFlags().StringVar(&cfg.model, "model", "gemma4-26b", "served model name")
+	root.PersistentFlags().IntVar(&cfg.maxQueue, "max-queue", defaultMaxQueue,
+		"pause worker when vLLM waiting queue reaches this depth")
+	root.PersistentFlags().IntVar(&cfg.port, "port", defaultPort, "local port for kubectl port-forward")
+
+	root.AddCommand(newRunCmd(&cfg))
+	root.AddCommand(newSweepCmd(&cfg))
+
+	return root
+}
+
+func newRunCmd(cfg *config) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "run",
+		Short: "Run a sustained throughput benchmark",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return runWithPortForward(cfg, func(ctx context.Context, baseURL string) {
+				runBench(ctx, baseURL, *cfg)
+			})
+		},
+	}
+
+	cmd.Flags().DurationVar(&cfg.duration, "duration", defaultDuration, "benchmark duration")
+	cmd.Flags().IntVar(&cfg.workers, "workers", 1, "concurrent workers; each sends requests sequentially")
+	cmd.Flags().IntVar(&cfg.maxTokens, "max-tokens", defaultMaxTokens, "max completion tokens per request")
+	cmd.Flags().StringVar(&cfg.prompt, "prompt", defaultPrompt, "prompt text")
+
+	return cmd
+}
+
+func newSweepCmd(cfg *config) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sweep",
+		Short: "Sweep context sizes and plot throughput vs latency",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return runWithPortForward(cfg, func(ctx context.Context, baseURL string) {
+				sizes := parseSweepSizes(cfg.sweepSizes)
+				runSweep(ctx, baseURL, *cfg, sizes)
+			})
+		},
+	}
+
+	cmd.Flags().StringVar(&cfg.sweepSizes, "sizes", defaultSweepSizes, "comma-separated input token targets")
+	cmd.Flags().IntVar(&cfg.sweepReqs, "requests", defaultSweepReqs, "requests per context size (averaged)")
+	cmd.Flags().IntVar(&cfg.sweepOutToks, "out-tokens", defaultSweepOutToks, "output tokens per request")
+
+	return cmd
+}
+
+func runWithPortForward(cfg *config, bench func(ctx context.Context, baseURL string)) error {
+	cfg.client = &http.Client{Timeout: clientTimeout}
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
 
 	pod, err := findPod(ctx, cfg.namespace, cfg.selector)
 	if err != nil {
-		cancel()
-
 		return fmt.Errorf("find pod: %w", err)
 	}
 
 	_, _ = fmt.Fprintf(os.Stdout, "pod: %s\n", pod)
 
 	pfCtx, pfCancel := context.WithCancel(ctx)
+	defer pfCancel()
 
 	err = startPortForward(pfCtx, cfg.namespace, pod, cfg.port)
 	if err != nil {
-		pfCancel()
-		cancel()
-
 		return fmt.Errorf("port-forward: %w", err)
 	}
 
-	defer pfCancel()
-	defer cancel()
-
 	baseURL := fmt.Sprintf("http://localhost:%d", cfg.port)
 
-	if cfg.sweep {
-		sizes := parseSweepSizes(cfg.sweepSizes)
-		runSweep(ctx, baseURL, cfg, sizes)
-	} else {
-		runBench(ctx, baseURL, cfg)
-	}
+	bench(ctx, baseURL)
 
 	return nil
 }
@@ -160,7 +185,7 @@ func startPortForward(ctx context.Context, namespace, pod string, localPort int)
 		return fmt.Errorf("start: %w", err)
 	}
 
-	// Monitor the command in a goroutine to catch unexpected exits
+	// Monitor the command in a goroutine to catch unexpected exits.
 	exitChan := make(chan error, 1)
 
 	go func() {
@@ -177,7 +202,7 @@ func startPortForward(ctx context.Context, namespace, pod string, localPort int)
 
 			_, _ = fmt.Fprintf(os.Stdout, "port-forward ready on localhost:%d\n\n", localPort)
 
-			// Wait for command to fail or context to be cancelled
+			// Wait for command to fail or context to be cancelled.
 			select {
 			case err := <-exitChan:
 				if err != nil {
@@ -199,9 +224,8 @@ func startPortForward(ctx context.Context, namespace, pod string, localPort int)
 		}
 	}
 
-	// Cleanup if timeout occurs
+	// Cleanup if timeout occurs.
 	_ = cmd.Process.Kill()
 
 	return fmt.Errorf("port-forward timeout: %w", errPortForwardTimeout)
 }
-

--- a/cmd/vllm-bench/main.go
+++ b/cmd/vllm-bench/main.go
@@ -153,7 +153,7 @@ func findPod(ctx context.Context, namespace, selector string) (string, error) {
 		Items []struct {
 			Metadata struct {
 				Name              string `json:"name"`
-				DeletionTimestamp string `json:"deletionTimestamp"`
+				DeletionTimestamp string `json:"deletionTimestamp"` //nolint:tagliatelle // Kubernetes API uses camelCase
 			} `json:"metadata"`
 		} `json:"items"`
 	}
@@ -178,7 +178,7 @@ func startPortForward(ctx context.Context, namespace, pod string, localPort int)
 		"-n", namespace, "pod/"+pod,
 		fmt.Sprintf("%d:8000", localPort),
 	)
-	cmd.Stderr = os.Stderr
+	cmd.Stderr = nil
 
 	err := cmd.Start()
 	if err != nil {
@@ -202,17 +202,7 @@ func startPortForward(ctx context.Context, namespace, pod string, localPort int)
 
 			_, _ = fmt.Fprintf(os.Stdout, "port-forward ready on localhost:%d\n\n", localPort)
 
-			// Wait for command to fail or context to be cancelled.
-			select {
-			case err := <-exitChan:
-				if err != nil {
-					return fmt.Errorf("port-forward process exited unexpectedly: %w", err)
-				}
-
-				return nil
-			case <-ctx.Done():
-				return fmt.Errorf("port-forward context error: %w", ctx.Err())
-			}
+			return nil
 		}
 
 		select {

--- a/cmd/vllm-bench/main.go
+++ b/cmd/vllm-bench/main.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -12,7 +13,6 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
-	"strings"
 	"syscall"
 	"time"
 )
@@ -118,18 +118,31 @@ func findPod(ctx context.Context, namespace, selector string) (string, error) {
 		"kubectl", "get", "pod",
 		"-n", namespace, "-l", selector,
 		"--field-selector=status.phase=Running",
-		"-o", "jsonpath={.items[0].metadata.name}",
+		"-o", "json",
 	).Output()
 	if err != nil {
 		return "", fmt.Errorf("command execution: %w", err)
 	}
 
-	name := strings.TrimSpace(string(out))
-	if name == "" {
-		return "", fmt.Errorf("selector %q in namespace %q: %w", selector, namespace, errNoPod)
+	var list struct {
+		Items []struct {
+			Metadata struct {
+				Name              string `json:"name"`
+				DeletionTimestamp string `json:"deletionTimestamp"`
+			} `json:"metadata"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(out, &list); err != nil {
+		return "", fmt.Errorf("parse pod list: %w", err)
 	}
 
-	return name, nil
+	for _, item := range list.Items {
+		if item.Metadata.DeletionTimestamp == "" {
+			return item.Metadata.Name, nil
+		}
+	}
+
+	return "", fmt.Errorf("selector %q in namespace %q: %w", selector, namespace, errNoPod)
 }
 
 func startPortForward(ctx context.Context, namespace, pod string, localPort int) error {
@@ -145,6 +158,12 @@ func startPortForward(ctx context.Context, namespace, pod string, localPort int)
 		return fmt.Errorf("start: %w", err)
 	}
 
+	// Monitor the command in a goroutine to catch unexpected exits
+	exitChan := make(chan error, 1)
+	go func() {
+		exitChan <- cmd.Wait()
+	}()
+
 	url := fmt.Sprintf("http://localhost:%d/metrics", localPort)
 
 	deadline := time.Now().Add(pfTimeout)
@@ -155,15 +174,29 @@ func startPortForward(ctx context.Context, namespace, pod string, localPort int)
 
 			_, _ = fmt.Fprintf(os.Stdout, "port-forward ready on localhost:%d\n\n", localPort)
 
-			return nil
+			// Wait for command to fail or context to be cancelled
+			select {
+			case err := <-exitChan:
+				if err != nil {
+					return fmt.Errorf("port-forward process exited unexpectedly: %w", err)
+				}
+				return nil
+			case <-ctx.Done():
+				return fmt.Errorf("port-forward context error: %w", ctx.Err())
+			}
 		}
 
 		select {
+		case err := <-exitChan:
+			return fmt.Errorf("port-forward process exited unexpectedly: %w", err)
 		case <-ctx.Done():
 			return fmt.Errorf("port-forward context error: %w", ctx.Err())
 		case <-time.After(backoffDuration):
 		}
 	}
 
+	// Cleanup if timeout occurs
+	_ = cmd.Process.Kill()
 	return fmt.Errorf("port-forward timeout: %w", errPortForwardTimeout)
 }
+

--- a/cmd/vllm-bench/main.go
+++ b/cmd/vllm-bench/main.go
@@ -1,0 +1,108 @@
+// Package main is the entry point for vllm-bench, a token throughput benchmark
+// for vLLM deployments running in Kubernetes.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+)
+
+var (
+	flagDuration     = flag.Duration("duration", 2*time.Minute, "benchmark duration (standard mode)")
+	flagWorkers      = flag.Int("workers", 1, "concurrent workers; each sends requests sequentially")
+	flagNamespace    = flag.String("namespace", "llm", "kubernetes namespace")
+	flagSelector     = flag.String("selector", "serving.kserve.io/inferenceservice=gemma4-moe", "pod label selector")
+	flagModel        = flag.String("model", "gemma4-26b-a4b-it", "served model name")
+	flagMaxTokens    = flag.Int("max-tokens", 512, "max completion tokens per request")
+	flagMaxQueue     = flag.Int("max-queue", 3, "pause worker when vLLM waiting queue reaches this depth")
+	flagPort         = flag.Int("port", 18000, "local port for kubectl port-forward")
+	flagPrompt       = flag.String("prompt", "Explain in detail how transformer attention mechanisms work in large language models.", "prompt for standard mode")
+	flagSweep        = flag.Bool("sweep", false, "sweep context sizes and plot results")
+	flagSweepSizes   = flag.String("sweep-sizes", "1024,4096,16384,32768,65536,131072", "comma-separated input token targets for sweep mode")
+	flagSweepReqs    = flag.Int("sweep-requests", 3, "requests per context size in sweep mode (averaged)")
+	flagSweepOutToks = flag.Int("sweep-out-tokens", 64, "output tokens per request in sweep mode")
+)
+
+func main() {
+	flag.Parse()
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	pod, err := findPod(ctx, *flagNamespace, *flagSelector)
+	if err != nil {
+		log.Fatalf("find pod: %v", err)
+	}
+	fmt.Printf("pod: %s\n", pod)
+
+	pfCtx, pfCancel := context.WithCancel(ctx)
+	defer pfCancel()
+
+	if err := startPortForward(pfCtx, *flagNamespace, pod, *flagPort); err != nil {
+		log.Fatalf("port-forward: %v", err)
+	}
+
+	baseURL := fmt.Sprintf("http://localhost:%d", *flagPort)
+
+	if *flagSweep {
+		sizes := parseSweepSizes(*flagSweepSizes)
+		runSweep(ctx, baseURL, sizes)
+	} else {
+		runBench(ctx, baseURL)
+	}
+}
+
+func findPod(ctx context.Context, ns, selector string) (string, error) {
+	out, err := exec.CommandContext(ctx,
+		"kubectl", "get", "pod",
+		"-n", ns, "-l", selector,
+		"--field-selector=status.phase=Running",
+		"-o", "jsonpath={.items[0].metadata.name}",
+	).Output()
+	if err != nil {
+		return "", err
+	}
+	name := strings.TrimSpace(string(out))
+	if name == "" {
+		return "", fmt.Errorf("no running pod for selector %q in namespace %q", selector, ns)
+	}
+	return name, nil
+}
+
+func startPortForward(ctx context.Context, ns, pod string, localPort int) error {
+	cmd := exec.CommandContext(ctx,
+		"kubectl", "port-forward",
+		"-n", ns, "pod/"+pod,
+		fmt.Sprintf("%d:8000", localPort),
+	)
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start: %w", err)
+	}
+
+	url := fmt.Sprintf("http://localhost:%d/metrics", localPort)
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(url) //nolint:noctx
+		if err == nil {
+			resp.Body.Close()
+			fmt.Printf("port-forward ready on localhost:%d\n\n", localPort)
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+	return fmt.Errorf("port-forward did not become ready within 30s")
+}

--- a/cmd/vllm-bench/main.go
+++ b/cmd/vllm-bench/main.go
@@ -61,12 +61,15 @@ func parseFlags() config {
 	flag.IntVar(&cfg.sweepReqs, "sweep-requests", defaultSweepReqs, "requests per context size in sweep mode (averaged)")
 	flag.IntVar(&cfg.sweepOutToks, "sweep-out-tokens", defaultSweepOutToks, "output tokens per request in sweep mode")
 	flag.Parse()
+
 	cfg.client = &http.Client{Timeout: clientTimeout}
+
 	return cfg
 }
 
 func main() {
-	if err := run(); err != nil {
+	err := run()
+	if err != nil {
 		log.Fatal(err)
 	}
 }
@@ -79,15 +82,19 @@ func run() error {
 	pod, err := findPod(ctx, cfg.namespace, cfg.selector)
 	if err != nil {
 		cancel()
+
 		return fmt.Errorf("find pod: %w", err)
 	}
+
 	_, _ = fmt.Fprintf(os.Stdout, "pod: %s\n", pod)
 
 	pfCtx, pfCancel := context.WithCancel(ctx)
 
-	if err := startPortForward(pfCtx, cfg.namespace, pod, cfg.port); err != nil {
+	err = startPortForward(pfCtx, cfg.namespace, pod, cfg.port)
+	if err != nil {
 		pfCancel()
 		cancel()
+
 		return fmt.Errorf("port-forward: %w", err)
 	}
 
@@ -102,51 +109,61 @@ func run() error {
 	} else {
 		runBench(ctx, baseURL, cfg)
 	}
+
 	return nil
 }
 
-func findPod(ctx context.Context, ns, selector string) (string, error) {
+func findPod(ctx context.Context, namespace, selector string) (string, error) {
 	out, err := exec.CommandContext(ctx, //nolint:gosec
 		"kubectl", "get", "pod",
-		"-n", ns, "-l", selector,
+		"-n", namespace, "-l", selector,
 		"--field-selector=status.phase=Running",
 		"-o", "jsonpath={.items[0].metadata.name}",
 	).Output()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("command execution: %w", err)
 	}
+
 	name := strings.TrimSpace(string(out))
 	if name == "" {
-		return "", fmt.Errorf("selector %q in namespace %q: %w", selector, ns, errNoPod)
+		return "", fmt.Errorf("selector %q in namespace %q: %w", selector, namespace, errNoPod)
 	}
+
 	return name, nil
 }
 
-func startPortForward(ctx context.Context, ns, pod string, localPort int) error {
+func startPortForward(ctx context.Context, namespace, pod string, localPort int) error {
 	cmd := exec.CommandContext(ctx, //nolint:gosec
 		"kubectl", "port-forward",
-		"-n", ns, "pod/"+pod,
+		"-n", namespace, "pod/"+pod,
 		fmt.Sprintf("%d:8000", localPort),
 	)
 	cmd.Stderr = os.Stderr
-	if err := cmd.Start(); err != nil {
+
+	err := cmd.Start()
+	if err != nil {
 		return fmt.Errorf("start: %w", err)
 	}
 
 	url := fmt.Sprintf("http://localhost:%d/metrics", localPort)
+
 	deadline := time.Now().Add(pfTimeout)
 	for time.Now().Before(deadline) {
 		resp, err := http.Get(url) //nolint:gosec,noctx
 		if err == nil {
 			_ = resp.Body.Close()
+
 			_, _ = fmt.Fprintf(os.Stdout, "port-forward ready on localhost:%d\n\n", localPort)
+
 			return nil
 		}
+
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return fmt.Errorf("port-forward context error: %w", ctx.Err())
 		case <-time.After(backoffDuration):
 		}
 	}
-	return errPortForwardTimeout
+
+	return fmt.Errorf("port-forward timeout: %w", errPortForwardTimeout)
 }

--- a/cmd/vllm-bench/main.go
+++ b/cmd/vllm-bench/main.go
@@ -132,7 +132,9 @@ func findPod(ctx context.Context, namespace, selector string) (string, error) {
 			} `json:"metadata"`
 		} `json:"items"`
 	}
-	if err := json.Unmarshal(out, &list); err != nil {
+
+	err = json.Unmarshal(out, &list)
+	if err != nil {
 		return "", fmt.Errorf("parse pod list: %w", err)
 	}
 
@@ -160,6 +162,7 @@ func startPortForward(ctx context.Context, namespace, pod string, localPort int)
 
 	// Monitor the command in a goroutine to catch unexpected exits
 	exitChan := make(chan error, 1)
+
 	go func() {
 		exitChan <- cmd.Wait()
 	}()
@@ -180,6 +183,7 @@ func startPortForward(ctx context.Context, namespace, pod string, localPort int)
 				if err != nil {
 					return fmt.Errorf("port-forward process exited unexpectedly: %w", err)
 				}
+
 				return nil
 			case <-ctx.Done():
 				return fmt.Errorf("port-forward context error: %w", ctx.Err())
@@ -197,6 +201,7 @@ func startPortForward(ctx context.Context, namespace, pod string, localPort int)
 
 	// Cleanup if timeout occurs
 	_ = cmd.Process.Kill()
+
 	return fmt.Errorf("port-forward timeout: %w", errPortForwardTimeout)
 }
 

--- a/cmd/vllm-bench/main.go
+++ b/cmd/vllm-bench/main.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -17,52 +18,95 @@ import (
 )
 
 var (
-	flagDuration     = flag.Duration("duration", 2*time.Minute, "benchmark duration (standard mode)")
-	flagWorkers      = flag.Int("workers", 1, "concurrent workers; each sends requests sequentially")
-	flagNamespace    = flag.String("namespace", "llm", "kubernetes namespace")
-	flagSelector     = flag.String("selector", "serving.kserve.io/inferenceservice=gemma4-moe", "pod label selector")
-	flagModel        = flag.String("model", "gemma4-26b-a4b-it", "served model name")
-	flagMaxTokens    = flag.Int("max-tokens", 512, "max completion tokens per request")
-	flagMaxQueue     = flag.Int("max-queue", 3, "pause worker when vLLM waiting queue reaches this depth")
-	flagPort         = flag.Int("port", 18000, "local port for kubectl port-forward")
-	flagPrompt       = flag.String("prompt", "Explain in detail how transformer attention mechanisms work in large language models.", "prompt for standard mode")
-	flagSweep        = flag.Bool("sweep", false, "sweep context sizes and plot results")
-	flagSweepSizes   = flag.String("sweep-sizes", "1024,4096,16384,32768,65536,131072", "comma-separated input token targets for sweep mode")
-	flagSweepReqs    = flag.Int("sweep-requests", 3, "requests per context size in sweep mode (averaged)")
-	flagSweepOutToks = flag.Int("sweep-out-tokens", 64, "output tokens per request in sweep mode")
+	errNoPod              = errors.New("no running pod found")
+	errPortForwardTimeout = errors.New("port-forward did not become ready within 30s")
 )
 
-func main() {
+const (
+	defaultSelector = "serving.kserve.io/inferenceservice=gemma4-moe"
+	defaultPrompt   = "Explain in detail how transformer attention mechanisms work in large language models."
+	defaultSweepSizes = "1024,4096,16384,32768,65536,131072"
+)
+
+type config struct {
+	duration     time.Duration
+	workers      int
+	namespace    string
+	selector     string
+	model        string
+	maxTokens    int
+	maxQueue     int
+	port         int
+	prompt       string
+	sweep        bool
+	sweepSizes   string
+	sweepReqs    int
+	sweepOutToks int
+	client       *http.Client
+}
+
+func parseFlags() config {
+	var cfg config
+	flag.DurationVar(&cfg.duration, "duration", defaultDuration, "benchmark duration (standard mode)")
+	flag.IntVar(&cfg.workers, "workers", 1, "concurrent workers; each sends requests sequentially")
+	flag.StringVar(&cfg.namespace, "namespace", "llm", "kubernetes namespace")
+	flag.StringVar(&cfg.selector, "selector", defaultSelector, "pod label selector")
+	flag.StringVar(&cfg.model, "model", "gemma4-26b-a4b-it", "served model name")
+	flag.IntVar(&cfg.maxTokens, "max-tokens", defaultMaxTokens, "max completion tokens per request")
+	flag.IntVar(&cfg.maxQueue, "max-queue", defaultMaxQueue, "pause worker when vLLM waiting queue reaches this depth")
+	flag.IntVar(&cfg.port, "port", defaultPort, "local port for kubectl port-forward")
+	flag.StringVar(&cfg.prompt, "prompt", defaultPrompt, "prompt for standard mode")
+	flag.BoolVar(&cfg.sweep, "sweep", false, "sweep context sizes and plot results")
+	flag.StringVar(&cfg.sweepSizes, "sweep-sizes", defaultSweepSizes, "comma-separated input token targets for sweep mode")
+	flag.IntVar(&cfg.sweepReqs, "sweep-requests", defaultSweepReqs, "requests per context size in sweep mode (averaged)")
+	flag.IntVar(&cfg.sweepOutToks, "sweep-out-tokens", defaultSweepOutToks, "output tokens per request in sweep mode")
 	flag.Parse()
+	cfg.client = &http.Client{Timeout: clientTimeout}
+	return cfg
+}
 
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer cancel()
-
-	pod, err := findPod(ctx, *flagNamespace, *flagSelector)
-	if err != nil {
-		log.Fatalf("find pod: %v", err)
-	}
-	fmt.Printf("pod: %s\n", pod)
-
-	pfCtx, pfCancel := context.WithCancel(ctx)
-	defer pfCancel()
-
-	if err := startPortForward(pfCtx, *flagNamespace, pod, *flagPort); err != nil {
-		log.Fatalf("port-forward: %v", err)
-	}
-
-	baseURL := fmt.Sprintf("http://localhost:%d", *flagPort)
-
-	if *flagSweep {
-		sizes := parseSweepSizes(*flagSweepSizes)
-		runSweep(ctx, baseURL, sizes)
-	} else {
-		runBench(ctx, baseURL)
+func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
 	}
 }
 
+func run() error {
+	cfg := parseFlags()
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+
+	pod, err := findPod(ctx, cfg.namespace, cfg.selector)
+	if err != nil {
+		cancel()
+		return fmt.Errorf("find pod: %w", err)
+	}
+	_, _ = fmt.Fprintf(os.Stdout, "pod: %s\n", pod)
+
+	pfCtx, pfCancel := context.WithCancel(ctx)
+
+	if err := startPortForward(pfCtx, cfg.namespace, pod, cfg.port); err != nil {
+		pfCancel()
+		cancel()
+		return fmt.Errorf("port-forward: %w", err)
+	}
+
+	defer pfCancel()
+	defer cancel()
+
+	baseURL := fmt.Sprintf("http://localhost:%d", cfg.port)
+
+	if cfg.sweep {
+		sizes := parseSweepSizes(cfg.sweepSizes)
+		runSweep(ctx, baseURL, cfg, sizes)
+	} else {
+		runBench(ctx, baseURL, cfg)
+	}
+	return nil
+}
+
 func findPod(ctx context.Context, ns, selector string) (string, error) {
-	out, err := exec.CommandContext(ctx,
+	out, err := exec.CommandContext(ctx, //nolint:gosec
 		"kubectl", "get", "pod",
 		"-n", ns, "-l", selector,
 		"--field-selector=status.phase=Running",
@@ -73,13 +117,13 @@ func findPod(ctx context.Context, ns, selector string) (string, error) {
 	}
 	name := strings.TrimSpace(string(out))
 	if name == "" {
-		return "", fmt.Errorf("no running pod for selector %q in namespace %q", selector, ns)
+		return "", fmt.Errorf("selector %q in namespace %q: %w", selector, ns, errNoPod)
 	}
 	return name, nil
 }
 
 func startPortForward(ctx context.Context, ns, pod string, localPort int) error {
-	cmd := exec.CommandContext(ctx,
+	cmd := exec.CommandContext(ctx, //nolint:gosec
 		"kubectl", "port-forward",
 		"-n", ns, "pod/"+pod,
 		fmt.Sprintf("%d:8000", localPort),
@@ -90,19 +134,19 @@ func startPortForward(ctx context.Context, ns, pod string, localPort int) error 
 	}
 
 	url := fmt.Sprintf("http://localhost:%d/metrics", localPort)
-	deadline := time.Now().Add(30 * time.Second)
+	deadline := time.Now().Add(pfTimeout)
 	for time.Now().Before(deadline) {
-		resp, err := http.Get(url) //nolint:noctx
+		resp, err := http.Get(url) //nolint:gosec,noctx
 		if err == nil {
-			resp.Body.Close()
-			fmt.Printf("port-forward ready on localhost:%d\n\n", localPort)
+			_ = resp.Body.Close()
+			_, _ = fmt.Fprintf(os.Stdout, "port-forward ready on localhost:%d\n\n", localPort)
 			return nil
 		}
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(500 * time.Millisecond):
+		case <-time.After(backoffDuration):
 		}
 	}
-	return fmt.Errorf("port-forward did not become ready within 30s")
+	return errPortForwardTimeout
 }

--- a/cmd/vllm-bench/main.go
+++ b/cmd/vllm-bench/main.go
@@ -23,7 +23,7 @@ var (
 )
 
 const (
-	defaultSelector = "serving.kserve.io/inferenceservice=gemma4-moe"
+	defaultSelector = "serving.kserve.io/inferenceservice=llm"
 	defaultPrompt   = "Explain in detail how transformer attention mechanisms work in large language models."
 	defaultSweepSizes = "1024,4096,16384,32768,65536,131072"
 )
@@ -51,7 +51,7 @@ func parseFlags() config {
 	flag.IntVar(&cfg.workers, "workers", 1, "concurrent workers; each sends requests sequentially")
 	flag.StringVar(&cfg.namespace, "namespace", "llm", "kubernetes namespace")
 	flag.StringVar(&cfg.selector, "selector", defaultSelector, "pod label selector")
-	flag.StringVar(&cfg.model, "model", "gemma-4-26b-a4b-it", "served model name")
+	flag.StringVar(&cfg.model, "model", "gemma4-26b", "served model name")
 	flag.IntVar(&cfg.maxTokens, "max-tokens", defaultMaxTokens, "max completion tokens per request")
 	flag.IntVar(&cfg.maxQueue, "max-queue", defaultMaxQueue, "pause worker when vLLM waiting queue reaches this depth")
 	flag.IntVar(&cfg.port, "port", defaultPort, "local port for kubectl port-forward")

--- a/cmd/vllm-bench/metrics.go
+++ b/cmd/vllm-bench/metrics.go
@@ -15,15 +15,17 @@ type vllmSnapshot struct {
 }
 
 func scrapeMetrics(url string) (vllmSnapshot, error) {
-	resp, err := http.Get(url) //nolint:noctx
+	resp, err := http.Get(url) //nolint:gosec,noctx
 	if err != nil {
 		return vllmSnapshot{}, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
+
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return vllmSnapshot{}, err
 	}
+
 	return vllmSnapshot{
 		running: parseGauge(body, "vllm:num_requests_running"),
 		waiting: parseGauge(body, "vllm:num_requests_waiting"),
@@ -39,7 +41,7 @@ func parseGauge(body []byte, name string) float64 {
 			continue
 		}
 		parts := strings.Fields(line)
-		if len(parts) < 2 {
+		if len(parts) < minPrometheusFields {
 			continue
 		}
 		v, err := strconv.ParseFloat(parts[len(parts)-1], 64)
@@ -47,5 +49,6 @@ func parseGauge(body []byte, name string) float64 {
 			return v
 		}
 	}
+
 	return 0
 }

--- a/cmd/vllm-bench/metrics.go
+++ b/cmd/vllm-bench/metrics.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"io"
 	"net/http"
 	"strconv"
@@ -17,13 +18,14 @@ type vllmSnapshot struct {
 func scrapeMetrics(url string) (vllmSnapshot, error) {
 	resp, err := http.Get(url) //nolint:gosec,noctx
 	if err != nil {
-		return vllmSnapshot{}, err
+		return vllmSnapshot{}, fmt.Errorf("http get: %w", err)
 	}
+
 	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return vllmSnapshot{}, err
+		return vllmSnapshot{}, fmt.Errorf("read response body: %w", err)
 	}
 
 	return vllmSnapshot{
@@ -40,10 +42,12 @@ func parseGauge(body []byte, name string) float64 {
 		if strings.HasPrefix(line, "#") || !strings.HasPrefix(line, name) {
 			continue
 		}
+
 		parts := strings.Fields(line)
 		if len(parts) < minPrometheusFields {
 			continue
 		}
+
 		v, err := strconv.ParseFloat(parts[len(parts)-1], 64)
 		if err == nil {
 			return v

--- a/cmd/vllm-bench/metrics.go
+++ b/cmd/vllm-bench/metrics.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+type vllmSnapshot struct {
+	running float64
+	waiting float64
+}
+
+func scrapeMetrics(url string) (vllmSnapshot, error) {
+	resp, err := http.Get(url) //nolint:noctx
+	if err != nil {
+		return vllmSnapshot{}, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return vllmSnapshot{}, err
+	}
+	return vllmSnapshot{
+		running: parseGauge(body, "vllm:num_requests_running"),
+		waiting: parseGauge(body, "vllm:num_requests_waiting"),
+	}, nil
+}
+
+// parseGauge extracts the first matching metric value from Prometheus text format.
+func parseGauge(body []byte, name string) float64 {
+	scanner := bufio.NewScanner(bytes.NewReader(body))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "#") || !strings.HasPrefix(line, name) {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) < 2 {
+			continue
+		}
+		v, err := strconv.ParseFloat(parts[len(parts)-1], 64)
+		if err == nil {
+			return v
+		}
+	}
+	return 0
+}

--- a/cmd/vllm-bench/openai.go
+++ b/cmd/vllm-bench/openai.go
@@ -16,7 +16,7 @@ var errUnexpectedStatus = errors.New("unexpected HTTP status")
 type chatRequest struct {
 	Model     string        `json:"model"`
 	Messages  []chatMessage `json:"messages"`
-	MaxTokens int           `json:"maxTokens"`
+	MaxTokens int           `json:"max_tokens"`
 	Stream    bool          `json:"stream"`
 }
 
@@ -27,8 +27,8 @@ type chatMessage struct {
 
 type chatResponse struct {
 	Usage struct {
-		PromptTokens     int `json:"promptTokens"`
-		CompletionTokens int `json:"completionTokens"`
+		PromptTokens     int `json:"prompt_tokens"`
+		CompletionTokens int `json:"completion_tokens"`
 	} `json:"usage"`
 }
 

--- a/cmd/vllm-bench/openai.go
+++ b/cmd/vllm-bench/openai.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+type chatRequest struct {
+	Model     string        `json:"model"`
+	Messages  []chatMessage `json:"messages"`
+	MaxTokens int           `json:"max_tokens"`
+	Stream    bool          `json:"stream"`
+}
+
+type chatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type chatResponse struct {
+	Usage struct {
+		PromptTokens     int `json:"prompt_tokens"`
+		CompletionTokens int `json:"completion_tokens"`
+	} `json:"usage"`
+}
+
+type inferenceResult struct {
+	promptTokens     int
+	completionTokens int
+	latency          time.Duration
+}
+
+var inferenceClient = &http.Client{Timeout: 15 * time.Minute}
+
+func sendChatCompletion(ctx context.Context, baseURL, model, prompt string, maxTokens int) (inferenceResult, error) {
+	body, err := json.Marshal(chatRequest{
+		Model:     model,
+		Messages:  []chatMessage{{Role: "user", Content: prompt}},
+		MaxTokens: maxTokens,
+		Stream:    false,
+	})
+	if err != nil {
+		return inferenceResult{}, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/v1/chat/completions", bytes.NewReader(body))
+	if err != nil {
+		return inferenceResult{}, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	start := time.Now()
+	resp, err := inferenceClient.Do(req)
+	if err != nil {
+		return inferenceResult{}, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		return inferenceResult{}, fmt.Errorf("HTTP %d: %s", resp.StatusCode, bytes.TrimSpace(b))
+	}
+
+	var cr chatResponse
+	if err := json.NewDecoder(resp.Body).Decode(&cr); err != nil {
+		return inferenceResult{}, fmt.Errorf("decode: %w", err)
+	}
+
+	return inferenceResult{
+		promptTokens:     cr.Usage.PromptTokens,
+		completionTokens: cr.Usage.CompletionTokens,
+		latency:          time.Since(start),
+	}, nil
+}

--- a/cmd/vllm-bench/openai.go
+++ b/cmd/vllm-bench/openai.go
@@ -16,7 +16,7 @@ var errUnexpectedStatus = errors.New("unexpected HTTP status")
 type chatRequest struct {
 	Model     string        `json:"model"`
 	Messages  []chatMessage `json:"messages"`
-	MaxTokens int           `json:"max_tokens"`
+	MaxTokens int           `json:"maxTokens"`
 	Stream    bool          `json:"stream"`
 }
 
@@ -27,8 +27,8 @@ type chatMessage struct {
 
 type chatResponse struct {
 	Usage struct {
-		PromptTokens     int `json:"prompt_tokens"`
-		CompletionTokens int `json:"completion_tokens"`
+		PromptTokens     int `json:"promptTokens"`
+		CompletionTokens int `json:"completionTokens"`
 	} `json:"usage"`
 }
 
@@ -49,35 +49,44 @@ func sendChatCompletion(
 		Stream:    false,
 	})
 	if err != nil {
-		return inferenceResult{}, err
+		return inferenceResult{}, fmt.Errorf("marshal request: %w", err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/v1/chat/completions", bytes.NewReader(body))
 	if err != nil {
-		return inferenceResult{}, err
+		return inferenceResult{}, fmt.Errorf("create request: %w", err)
 	}
+
 	req.Header.Set("Content-Type", "application/json")
 
 	start := time.Now()
+
 	resp, err := client.Do(req)
 	if err != nil {
-		return inferenceResult{}, err
+		return inferenceResult{}, fmt.Errorf("do request: %w", err)
 	}
+
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		b, _ := io.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return inferenceResult{}, fmt.Errorf("read error body: %w", err)
+		}
+
 		return inferenceResult{}, fmt.Errorf("%w: %d %s", errUnexpectedStatus, resp.StatusCode, bytes.TrimSpace(b))
 	}
 
-	var cr chatResponse
-	if err := json.NewDecoder(resp.Body).Decode(&cr); err != nil {
-		return inferenceResult{}, fmt.Errorf("decode: %w", err)
+	var chatResp chatResponse
+
+	err = json.NewDecoder(resp.Body).Decode(&chatResp)
+	if err != nil {
+		return inferenceResult{}, fmt.Errorf("decode response: %w", err)
 	}
 
 	return inferenceResult{
-		promptTokens:     cr.Usage.PromptTokens,
-		completionTokens: cr.Usage.CompletionTokens,
+		promptTokens:     chatResp.Usage.PromptTokens,
+		completionTokens: chatResp.Usage.CompletionTokens,
 		latency:          time.Since(start),
 	}, nil
 }

--- a/cmd/vllm-bench/openai.go
+++ b/cmd/vllm-bench/openai.go
@@ -4,11 +4,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"time"
 )
+
+var errUnexpectedStatus = errors.New("unexpected HTTP status")
 
 type chatRequest struct {
 	Model     string        `json:"model"`
@@ -35,9 +38,10 @@ type inferenceResult struct {
 	latency          time.Duration
 }
 
-var inferenceClient = &http.Client{Timeout: 15 * time.Minute}
-
-func sendChatCompletion(ctx context.Context, baseURL, model, prompt string, maxTokens int) (inferenceResult, error) {
+func sendChatCompletion(
+	ctx context.Context, client *http.Client,
+	baseURL, model, prompt string, maxTokens int,
+) (inferenceResult, error) {
 	body, err := json.Marshal(chatRequest{
 		Model:     model,
 		Messages:  []chatMessage{{Role: "user", Content: prompt}},
@@ -55,15 +59,15 @@ func sendChatCompletion(ctx context.Context, baseURL, model, prompt string, maxT
 	req.Header.Set("Content-Type", "application/json")
 
 	start := time.Now()
-	resp, err := inferenceClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return inferenceResult{}, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		b, _ := io.ReadAll(resp.Body)
-		return inferenceResult{}, fmt.Errorf("HTTP %d: %s", resp.StatusCode, bytes.TrimSpace(b))
+		return inferenceResult{}, fmt.Errorf("%w: %d %s", errUnexpectedStatus, resp.StatusCode, bytes.TrimSpace(b))
 	}
 
 	var cr chatResponse

--- a/cmd/vllm-bench/plot.go
+++ b/cmd/vllm-bench/plot.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/guptarohit/asciigraph"
+)
+
+// lineChart renders a titled line chart with custom x-axis labels.
+func lineChart(title string, xLabels []string, values []float64, yUnit string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	plot := asciigraph.Plot(values,
+		asciigraph.Caption(title),
+		asciigraph.Height(10),
+		asciigraph.Width(max(60, len(xLabels)*8)),
+	)
+
+	// Build x-axis label row aligned under each data point.
+	// asciigraph leaves a left margin for the y-axis; approximate it.
+	yAxisWidth := yAxisMargin(values)
+	step := max(60, len(xLabels)*8) / max(len(xLabels)-1, 1)
+	var axis strings.Builder
+	axis.WriteString(strings.Repeat(" ", yAxisWidth))
+	for i, l := range xLabels {
+		pad := step - len(l)
+		if i == 0 {
+			axis.WriteString(l)
+		} else {
+			axis.WriteString(strings.Repeat(" ", max(pad, 1)))
+			axis.WriteString(l)
+		}
+	}
+	_ = yUnit
+	return plot + "\n" + axis.String()
+}
+
+// yAxisMargin estimates the left-margin width asciigraph uses for y-axis labels.
+func yAxisMargin(values []float64) int {
+	maxVal := 0.0
+	for _, v := range values {
+		if v > maxVal {
+			maxVal = v
+		}
+	}
+	digits := len(fmt.Sprintf("%.2f", maxVal))
+	return digits + 2 // asciigraph pads with " " + value + " ┤"
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+// roundSigFig rounds v to 3 significant figures for axis labels.
+func roundSigFig(v float64) float64 {
+	if v == 0 {
+		return 0
+	}
+	p := math.Pow(10, math.Floor(math.Log10(math.Abs(v)))-2)
+	return math.Round(v/p) * p
+}

--- a/cmd/vllm-bench/plot.go
+++ b/cmd/vllm-bench/plot.go
@@ -2,27 +2,25 @@ package main
 
 import (
 	"fmt"
-	"math"
 	"strings"
 
 	"github.com/guptarohit/asciigraph"
 )
 
 // lineChart renders a titled line chart with custom x-axis labels.
-func lineChart(title string, xLabels []string, values []float64, yUnit string) string {
+func lineChart(title string, xLabels []string, values []float64, _ string) string {
 	if len(values) == 0 {
 		return ""
 	}
+	width := max(minChartWidth, len(xLabels)*8)
 	plot := asciigraph.Plot(values,
 		asciigraph.Caption(title),
-		asciigraph.Height(10),
-		asciigraph.Width(max(60, len(xLabels)*8)),
+		asciigraph.Height(chartHeight),
+		asciigraph.Width(width),
 	)
 
-	// Build x-axis label row aligned under each data point.
-	// asciigraph leaves a left margin for the y-axis; approximate it.
 	yAxisWidth := yAxisMargin(values)
-	step := max(60, len(xLabels)*8) / max(len(xLabels)-1, 1)
+	step := width / max(len(xLabels)-1, 1)
 	var axis strings.Builder
 	axis.WriteString(strings.Repeat(" ", yAxisWidth))
 	for i, l := range xLabels {
@@ -34,7 +32,7 @@ func lineChart(title string, xLabels []string, values []float64, yUnit string) s
 			axis.WriteString(l)
 		}
 	}
-	_ = yUnit
+
 	return plot + "\n" + axis.String()
 }
 
@@ -46,22 +44,6 @@ func yAxisMargin(values []float64) int {
 			maxVal = v
 		}
 	}
-	digits := len(fmt.Sprintf("%.2f", maxVal))
-	return digits + 2 // asciigraph pads with " " + value + " ┤"
-}
 
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
-
-// roundSigFig rounds v to 3 significant figures for axis labels.
-func roundSigFig(v float64) float64 {
-	if v == 0 {
-		return 0
-	}
-	p := math.Pow(10, math.Floor(math.Log10(math.Abs(v)))-2)
-	return math.Round(v/p) * p
+	return len(fmt.Sprintf("%.2f", maxVal)) + yAxisPadding
 }

--- a/cmd/vllm-bench/plot.go
+++ b/cmd/vllm-bench/plot.go
@@ -12,7 +12,10 @@ func lineChart(title string, xLabels []string, values []float64, _ string) strin
 	if len(values) == 0 {
 		return ""
 	}
-	width := max(minChartWidth, len(xLabels)*8)
+
+	const labelMultiplier = 8
+
+	width := max(minChartWidth, len(xLabels)*labelMultiplier)
 	plot := asciigraph.Plot(values,
 		asciigraph.Caption(title),
 		asciigraph.Height(chartHeight),
@@ -21,15 +24,17 @@ func lineChart(title string, xLabels []string, values []float64, _ string) strin
 
 	yAxisWidth := yAxisMargin(values)
 	step := width / max(len(xLabels)-1, 1)
+
 	var axis strings.Builder
 	axis.WriteString(strings.Repeat(" ", yAxisWidth))
-	for i, l := range xLabels {
-		pad := step - len(l)
-		if i == 0 {
-			axis.WriteString(l)
+
+	for labelIdx, labelName := range xLabels {
+		pad := step - len(labelName)
+		if labelIdx == 0 {
+			axis.WriteString(labelName)
 		} else {
 			axis.WriteString(strings.Repeat(" ", max(pad, 1)))
-			axis.WriteString(l)
+			axis.WriteString(labelName)
 		}
 	}
 

--- a/cmd/vllm-bench/plot.go
+++ b/cmd/vllm-bench/plot.go
@@ -26,10 +26,12 @@ func lineChart(title string, xLabels []string, values []float64, _ string) strin
 	step := width / max(len(xLabels)-1, 1)
 
 	var axis strings.Builder
+
 	axis.WriteString(strings.Repeat(" ", yAxisWidth))
 
 	for labelIdx, labelName := range xLabels {
 		pad := step - len(labelName)
+
 		if labelIdx == 0 {
 			axis.WriteString(labelName)
 		} else {
@@ -41,9 +43,152 @@ func lineChart(title string, xLabels []string, values []float64, _ string) strin
 	return plot + "\n" + axis.String()
 }
 
+// errorBarChart renders a chart with vertical error bars (min–max) and a * marker for the average.
+func errorBarChart(title string, xLabels []string, mins, avgs, maxs []float64) string {
+	numPoints := len(avgs)
+	if numPoints == 0 {
+		return ""
+	}
+
+	const labelMultiplier = 8
+
+	width := max(minChartWidth, numPoints*labelMultiplier)
+	globalMin, globalMax := yRange(mins, maxs)
+	cols := columnPositions(numPoints, width)
+	grid := makeEmptyGrid(chartHeight, width)
+
+	fillErrorBars(grid, cols, mins, avgs, maxs, globalMin, globalMax)
+
+	return renderErrorBarChart(title, xLabels, grid, globalMin, globalMax, width)
+}
+
+func yRange(mins, maxs []float64) (float64, float64) {
+	globalMin, globalMax := mins[0], maxs[0]
+
+	for idx := range mins {
+		if mins[idx] < globalMin {
+			globalMin = mins[idx]
+		}
+
+		if maxs[idx] > globalMax {
+			globalMax = maxs[idx]
+		}
+	}
+
+	return globalMin, globalMax
+}
+
+func columnPositions(count, width int) []int {
+	cols := make([]int, count)
+
+	if count > 1 {
+		for i := range count {
+			cols[i] = i * (width - 1) / (count - 1)
+		}
+
+		return cols
+	}
+
+	cols[0] = width / halfDivisor
+
+	return cols
+}
+
+func makeEmptyGrid(rows, cols int) [][]rune {
+	grid := make([][]rune, rows)
+
+	for r := range rows {
+		grid[r] = make([]rune, cols)
+
+		for c := range cols {
+			grid[r][c] = ' '
+		}
+	}
+
+	return grid
+}
+
+func valueToRow(v, globalMin, globalMax float64) int {
+	if globalMax == globalMin {
+		return chartHeight / halfDivisor
+	}
+
+	row := int((globalMax-v)/(globalMax-globalMin)*float64(chartHeight-1) + roundingHalf)
+
+	if row < 0 {
+		return 0
+	}
+
+	if row >= chartHeight {
+		return chartHeight - 1
+	}
+
+	return row
+}
+
+func fillErrorBars(grid [][]rune, cols []int, mins, avgs, maxs []float64, globalMin, globalMax float64) {
+	for i := range cols {
+		col := cols[i]
+		topRow := valueToRow(maxs[i], globalMin, globalMax)
+		botRow := valueToRow(mins[i], globalMin, globalMax)
+		avgRow := valueToRow(avgs[i], globalMin, globalMax)
+
+		for r := topRow; r <= botRow; r++ {
+			grid[r][col] = '│'
+		}
+
+		grid[avgRow][col] = '*'
+	}
+}
+
+func renderErrorBarChart(
+	title string, xLabels []string, grid [][]rune, globalMin, globalMax float64, width int,
+) string {
+	yAxisWidth := len(fmt.Sprintf("%.2f", globalMax)) + yAxisPadding
+	labelFmt := fmt.Sprintf("%%%d.2f ┤", yAxisWidth-yAxisPadding)
+
+	var output strings.Builder
+
+	for r := range chartHeight {
+		yVal := globalMax - float64(r)/float64(chartHeight-1)*(globalMax-globalMin)
+
+		fmt.Fprintf(&output, labelFmt, yVal)
+		output.WriteString(string(grid[r]))
+		output.WriteByte('\n')
+	}
+
+	titlePad := max((yAxisWidth+width-len(title))/halfDivisor, 0)
+	output.WriteString(strings.Repeat(" ", titlePad))
+	output.WriteString(title)
+	output.WriteByte('\n')
+
+	writeXAxisLabels(&output, xLabels, yAxisWidth, width)
+
+	return output.String()
+}
+
+func writeXAxisLabels(output *strings.Builder, xLabels []string, yAxisWidth, width int) {
+	output.WriteString(strings.Repeat(" ", yAxisWidth))
+
+	step := width / max(len(xLabels)-1, 1)
+
+	for labelIdx, label := range xLabels {
+		if labelIdx == 0 {
+			output.WriteString(label)
+
+			continue
+		}
+
+		pad := step - len(label)
+		output.WriteString(strings.Repeat(" ", max(pad, 1)))
+		output.WriteString(label)
+	}
+}
+
 // yAxisMargin estimates the left-margin width asciigraph uses for y-axis labels.
 func yAxisMargin(values []float64) int {
 	maxVal := 0.0
+
 	for _, v := range values {
 		if v > maxVal {
 			maxVal = v

--- a/cmd/vllm-bench/sweep.go
+++ b/cmd/vllm-bench/sweep.go
@@ -47,18 +47,18 @@ func runSweep(ctx context.Context, baseURL string, cfg config, sizes []int) {
 			break
 		}
 
-		_, _ = fmt.Fprintf(os.Stdout, "context ~%dk tokens ... ", target/tokensPerK)
+		_, _ = fmt.Fprintf(os.Stdout, "context ~%dk tokens ...\n", target/tokensPerK)
 
 		sweepPoint, ok := measureSweepPoint(ctx, baseURL, cfg, target)
 		if !ok {
-			_, _ = fmt.Fprintln(os.Stdout, "all requests failed, skipping")
+			_, _ = fmt.Fprintln(os.Stdout, "  all requests failed, skipping")
 
 			continue
 		}
 
 		results = append(results, sweepPoint)
 		_, _ = fmt.Fprintf(os.Stdout,
-			"prompt=%d  lat min=%s avg=%s max=%s  tok/s min=%.1f avg=%.1f max=%.1f\n",
+			"  prompt=%d\n  lat min=%s avg=%s max=%s\n  tok/s min=%.1f avg=%.1f max=%.1f\n",
 			sweepPoint.promptTokens,
 			sweepPoint.minLatency.Round(time.Millisecond),
 			sweepPoint.avgLatency.Round(time.Millisecond),

--- a/cmd/vllm-bench/sweep.go
+++ b/cmd/vllm-bench/sweep.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type sweepPoint struct {
+	targetTokens     int
+	promptTokens     int
+	completionTokens int
+	latency          time.Duration
+}
+
+func parseSweepSizes(s string) []int {
+	var sizes []int
+	for _, part := range strings.Split(s, ",") {
+		v, err := strconv.Atoi(strings.TrimSpace(part))
+		if err == nil && v > 0 {
+			sizes = append(sizes, v)
+		}
+	}
+	return sizes
+}
+
+func runSweep(ctx context.Context, baseURL string, sizes []int) {
+	fmt.Printf("sweep: %d context sizes, %d requests each, %d output tokens\n\n",
+		len(sizes), *flagSweepReqs, *flagSweepOutToks)
+
+	results := make([]sweepPoint, 0, len(sizes))
+
+	for _, target := range sizes {
+		if ctx.Err() != nil {
+			break
+		}
+		fmt.Printf("context ~%dk tokens ... ", target/1024)
+		prompt := paddedPrompt(target)
+
+		var totalLat time.Duration
+		var totalPrompt, totalCompletion int
+		var succeeded int
+
+		for i := range *flagSweepReqs {
+			if ctx.Err() != nil {
+				break
+			}
+			// wait for queue to clear before each sweep request
+			for {
+				snap, err := scrapeMetrics(baseURL + "/metrics")
+				if err != nil || snap.waiting < float64(*flagMaxQueue) {
+					break
+				}
+				select {
+				case <-ctx.Done():
+					break
+				case <-time.After(500 * time.Millisecond):
+				}
+			}
+
+			result, err := sendChatCompletion(ctx, baseURL, *flagModel, prompt, *flagSweepOutToks)
+			if err != nil {
+				log.Printf("request %d for %d tokens: %v", i+1, target, err)
+				continue
+			}
+			totalLat += result.latency
+			totalPrompt += result.promptTokens
+			totalCompletion += result.completionTokens
+			succeeded++
+		}
+
+		if succeeded == 0 {
+			fmt.Println("all requests failed, skipping")
+			continue
+		}
+
+		pt := sweepPoint{
+			targetTokens:     target,
+			promptTokens:     totalPrompt / succeeded,
+			completionTokens: totalCompletion / succeeded,
+			latency:          totalLat / time.Duration(succeeded),
+		}
+		results = append(results, pt)
+		tokPerSec := float64(pt.completionTokens) / pt.latency.Seconds()
+		fmt.Printf("prompt=%d  lat=%s  tok/s=%.1f\n",
+			pt.promptTokens,
+			pt.latency.Round(time.Millisecond),
+			tokPerSec,
+		)
+	}
+
+	if len(results) < 2 {
+		fmt.Println("not enough data points for charts")
+		return
+	}
+
+	printSweepCharts(results)
+}
+
+func printSweepCharts(results []sweepPoint) {
+	labels := make([]string, len(results))
+	latencies := make([]float64, len(results))
+	throughputs := make([]float64, len(results))
+
+	for i, r := range results {
+		k := r.promptTokens / 1024
+		if k == 0 {
+			labels[i] = fmt.Sprintf("%dt", r.promptTokens)
+		} else {
+			labels[i] = fmt.Sprintf("%dk", k)
+		}
+		latencies[i] = r.latency.Seconds()
+		throughputs[i] = float64(r.completionTokens) / r.latency.Seconds()
+	}
+
+	fmt.Println()
+	fmt.Println(lineChart("Context window vs latency (s)", labels, latencies, "s"))
+	fmt.Println()
+	fmt.Println(lineChart("Context window vs throughput (tok/s)", labels, throughputs, "tok/s"))
+}
+
+// paddedPrompt returns a prompt whose token count is approximately targetTokens.
+// It fills a system-like preamble with repeated text and appends a short question.
+// Approximation: 1 token ≈ 3.5 characters for English prose.
+func paddedPrompt(targetTokens int) string {
+	question := "Summarise the above in one sentence."
+	charsNeeded := int(float64(targetTokens)*3.5) - len(question) - 20
+	if charsNeeded < 0 {
+		return question
+	}
+
+	seed := "The transformer architecture relies on self-attention mechanisms that allow each token in a sequence to attend to every other token, enabling the model to capture long-range dependencies efficiently. "
+	var sb strings.Builder
+	for sb.Len() < charsNeeded {
+		sb.WriteString(seed)
+	}
+	return sb.String()[:charsNeeded] + "\n\n" + question
+}

--- a/cmd/vllm-bench/sweep.go
+++ b/cmd/vllm-bench/sweep.go
@@ -19,6 +19,7 @@ type sweepPoint struct {
 
 func parseSweepSizes(s string) []int {
 	var sizes []int
+
 	for part := range strings.SplitSeq(s, ",") {
 		v, err := strconv.Atoi(strings.TrimSpace(part))
 		if err == nil && v > 0 {
@@ -39,20 +40,21 @@ func runSweep(ctx context.Context, baseURL string, cfg config, sizes []int) {
 		if ctx.Err() != nil {
 			break
 		}
-		_, _ = fmt.Fprintf(os.Stdout, "context ~%dk tokens ... ", target/tokensPerK)
 
-		pt, ok := measureSweepPoint(ctx, baseURL, cfg, target)
-		if !ok {
-			_, _ = fmt.Fprintln(os.Stdout, "all requests failed, skipping")
+	_, _ = fmt.Fprintf(os.Stdout, "context ~%dk tokens ... ", target/tokensPerK)
 
-			continue
-		}
+	sweepPoint, ok := measureSweepPoint(ctx, baseURL, cfg, target)
+	if !ok {
+		_, _ = fmt.Fprintln(os.Stdout, "all requests failed, skipping")
 
-		results = append(results, pt)
+		continue
+	}
+
+		results = append(results, sweepPoint)
 		_, _ = fmt.Fprintf(os.Stdout, "prompt=%d  lat=%s  tok/s=%.1f\n",
-			pt.promptTokens,
-			pt.latency.Round(time.Millisecond),
-			float64(pt.completionTokens)/pt.latency.Seconds(),
+			sweepPoint.promptTokens,
+			sweepPoint.latency.Round(time.Millisecond),
+			float64(sweepPoint.completionTokens)/sweepPoint.latency.Seconds(),
 		)
 	}
 
@@ -67,21 +69,25 @@ func runSweep(ctx context.Context, baseURL string, cfg config, sizes []int) {
 
 func measureSweepPoint(ctx context.Context, baseURL string, cfg config, target int) (sweepPoint, bool) {
 	prompt := paddedPrompt(target)
+
 	var totalLat time.Duration
+
 	var totalPrompt, totalCompletion, succeeded int
 
-	for i := range cfg.sweepReqs {
+	for sweepIdx := range cfg.sweepReqs {
 		if ctx.Err() != nil {
 			break
 		}
+
 		waitForCapacity(ctx, baseURL, cfg)
 
 		result, err := sendChatCompletion(ctx, cfg.client, baseURL, cfg.model, prompt, cfg.sweepOutToks)
 		if err != nil {
-			log.Printf("request %d for %d tokens: %v", i+1, target, err)
+			log.Printf("request %d for %d tokens: %v", sweepIdx+1, target, err)
 
 			continue
 		}
+
 		totalLat += result.latency
 		totalPrompt += result.promptTokens
 		totalCompletion += result.completionTokens
@@ -102,12 +108,13 @@ func measureSweepPoint(ctx context.Context, baseURL string, cfg config, target i
 
 // waitForCapacity blocks until vLLM's waiting queue has room or the context is cancelled.
 func waitForCapacity(ctx context.Context, baseURL string, cfg config) {
-waitLoop:
+	waitLoop:
 	for {
 		snap, err := scrapeMetrics(baseURL + "/metrics")
 		if err != nil || snap.waiting < float64(cfg.maxQueue) {
 			break waitLoop
 		}
+
 		select {
 		case <-ctx.Done():
 			break waitLoop
@@ -121,15 +128,16 @@ func printSweepCharts(results []sweepPoint) {
 	latencies := make([]float64, len(results))
 	throughputs := make([]float64, len(results))
 
-	for i, r := range results {
-		k := r.promptTokens / tokensPerK
+	for idx, result := range results {
+		k := result.promptTokens / tokensPerK
 		if k == 0 {
-			labels[i] = fmt.Sprintf("%dt", r.promptTokens)
+			labels[idx] = fmt.Sprintf("%dt", result.promptTokens)
 		} else {
-			labels[i] = fmt.Sprintf("%dk", k)
+			labels[idx] = fmt.Sprintf("%dk", k)
 		}
-		latencies[i] = r.latency.Seconds()
-		throughputs[i] = float64(r.completionTokens) / r.latency.Seconds()
+
+		latencies[idx] = result.latency.Seconds()
+		throughputs[idx] = float64(result.completionTokens) / result.latency.Seconds()
 	}
 
 	_, _ = fmt.Fprintln(os.Stdout)
@@ -142,13 +150,16 @@ func printSweepCharts(results []sweepPoint) {
 // Approximation: 1 token ≈ 3.5 characters for English prose.
 func paddedPrompt(targetTokens int) string {
 	question := "Summarise the above in one sentence."
+
 	charsNeeded := int(float64(targetTokens)*charsPerToken) - len(question) - paddingOverhead
 	if charsNeeded < 0 {
 		return question
 	}
+
 	seed := "The transformer architecture relies on self-attention mechanisms " +
 		"that allow each token in a sequence to attend to every other token, " +
 		"enabling the model to capture long-range dependencies efficiently. "
+
 	var sb strings.Builder
 	for sb.Len() < charsNeeded {
 		sb.WriteString(seed)

--- a/cmd/vllm-bench/sweep.go
+++ b/cmd/vllm-bench/sweep.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -18,18 +19,19 @@ type sweepPoint struct {
 
 func parseSweepSizes(s string) []int {
 	var sizes []int
-	for _, part := range strings.Split(s, ",") {
+	for part := range strings.SplitSeq(s, ",") {
 		v, err := strconv.Atoi(strings.TrimSpace(part))
 		if err == nil && v > 0 {
 			sizes = append(sizes, v)
 		}
 	}
+
 	return sizes
 }
 
-func runSweep(ctx context.Context, baseURL string, sizes []int) {
-	fmt.Printf("sweep: %d context sizes, %d requests each, %d output tokens\n\n",
-		len(sizes), *flagSweepReqs, *flagSweepOutToks)
+func runSweep(ctx context.Context, baseURL string, cfg config, sizes []int) {
+	_, _ = fmt.Fprintf(os.Stdout, "sweep: %d context sizes, %d requests each, %d output tokens\n\n",
+		len(sizes), cfg.sweepReqs, cfg.sweepOutToks)
 
 	results := make([]sweepPoint, 0, len(sizes))
 
@@ -37,67 +39,81 @@ func runSweep(ctx context.Context, baseURL string, sizes []int) {
 		if ctx.Err() != nil {
 			break
 		}
-		fmt.Printf("context ~%dk tokens ... ", target/1024)
-		prompt := paddedPrompt(target)
+		_, _ = fmt.Fprintf(os.Stdout, "context ~%dk tokens ... ", target/tokensPerK)
 
-		var totalLat time.Duration
-		var totalPrompt, totalCompletion int
-		var succeeded int
+		pt, ok := measureSweepPoint(ctx, baseURL, cfg, target)
+		if !ok {
+			_, _ = fmt.Fprintln(os.Stdout, "all requests failed, skipping")
 
-		for i := range *flagSweepReqs {
-			if ctx.Err() != nil {
-				break
-			}
-			// wait for queue to clear before each sweep request
-			for {
-				snap, err := scrapeMetrics(baseURL + "/metrics")
-				if err != nil || snap.waiting < float64(*flagMaxQueue) {
-					break
-				}
-				select {
-				case <-ctx.Done():
-					break
-				case <-time.After(500 * time.Millisecond):
-				}
-			}
-
-			result, err := sendChatCompletion(ctx, baseURL, *flagModel, prompt, *flagSweepOutToks)
-			if err != nil {
-				log.Printf("request %d for %d tokens: %v", i+1, target, err)
-				continue
-			}
-			totalLat += result.latency
-			totalPrompt += result.promptTokens
-			totalCompletion += result.completionTokens
-			succeeded++
-		}
-
-		if succeeded == 0 {
-			fmt.Println("all requests failed, skipping")
 			continue
 		}
 
-		pt := sweepPoint{
-			targetTokens:     target,
-			promptTokens:     totalPrompt / succeeded,
-			completionTokens: totalCompletion / succeeded,
-			latency:          totalLat / time.Duration(succeeded),
-		}
 		results = append(results, pt)
-		tokPerSec := float64(pt.completionTokens) / pt.latency.Seconds()
-		fmt.Printf("prompt=%d  lat=%s  tok/s=%.1f\n",
+		_, _ = fmt.Fprintf(os.Stdout, "prompt=%d  lat=%s  tok/s=%.1f\n",
 			pt.promptTokens,
 			pt.latency.Round(time.Millisecond),
-			tokPerSec,
+			float64(pt.completionTokens)/pt.latency.Seconds(),
 		)
 	}
 
-	if len(results) < 2 {
-		fmt.Println("not enough data points for charts")
+	if len(results) < minChartSamples {
+		_, _ = fmt.Fprintln(os.Stdout, "not enough data points for charts")
+
 		return
 	}
 
 	printSweepCharts(results)
+}
+
+func measureSweepPoint(ctx context.Context, baseURL string, cfg config, target int) (sweepPoint, bool) {
+	prompt := paddedPrompt(target)
+	var totalLat time.Duration
+	var totalPrompt, totalCompletion, succeeded int
+
+	for i := range cfg.sweepReqs {
+		if ctx.Err() != nil {
+			break
+		}
+		waitForCapacity(ctx, baseURL, cfg)
+
+		result, err := sendChatCompletion(ctx, cfg.client, baseURL, cfg.model, prompt, cfg.sweepOutToks)
+		if err != nil {
+			log.Printf("request %d for %d tokens: %v", i+1, target, err)
+
+			continue
+		}
+		totalLat += result.latency
+		totalPrompt += result.promptTokens
+		totalCompletion += result.completionTokens
+		succeeded++
+	}
+
+	if succeeded == 0 {
+		return sweepPoint{}, false
+	}
+
+	return sweepPoint{
+		targetTokens:     target,
+		promptTokens:     totalPrompt / succeeded,
+		completionTokens: totalCompletion / succeeded,
+		latency:          totalLat / time.Duration(succeeded),
+	}, true
+}
+
+// waitForCapacity blocks until vLLM's waiting queue has room or the context is cancelled.
+func waitForCapacity(ctx context.Context, baseURL string, cfg config) {
+waitLoop:
+	for {
+		snap, err := scrapeMetrics(baseURL + "/metrics")
+		if err != nil || snap.waiting < float64(cfg.maxQueue) {
+			break waitLoop
+		}
+		select {
+		case <-ctx.Done():
+			break waitLoop
+		case <-time.After(backoffDuration):
+		}
+	}
 }
 
 func printSweepCharts(results []sweepPoint) {
@@ -106,7 +122,7 @@ func printSweepCharts(results []sweepPoint) {
 	throughputs := make([]float64, len(results))
 
 	for i, r := range results {
-		k := r.promptTokens / 1024
+		k := r.promptTokens / tokensPerK
 		if k == 0 {
 			labels[i] = fmt.Sprintf("%dt", r.promptTokens)
 		} else {
@@ -116,26 +132,27 @@ func printSweepCharts(results []sweepPoint) {
 		throughputs[i] = float64(r.completionTokens) / r.latency.Seconds()
 	}
 
-	fmt.Println()
-	fmt.Println(lineChart("Context window vs latency (s)", labels, latencies, "s"))
-	fmt.Println()
-	fmt.Println(lineChart("Context window vs throughput (tok/s)", labels, throughputs, "tok/s"))
+	_, _ = fmt.Fprintln(os.Stdout)
+	_, _ = fmt.Fprintln(os.Stdout, lineChart("Context window vs latency (s)", labels, latencies, "s"))
+	_, _ = fmt.Fprintln(os.Stdout)
+	_, _ = fmt.Fprintln(os.Stdout, lineChart("Context window vs throughput (tok/s)", labels, throughputs, "tok/s"))
 }
 
 // paddedPrompt returns a prompt whose token count is approximately targetTokens.
-// It fills a system-like preamble with repeated text and appends a short question.
 // Approximation: 1 token ≈ 3.5 characters for English prose.
 func paddedPrompt(targetTokens int) string {
 	question := "Summarise the above in one sentence."
-	charsNeeded := int(float64(targetTokens)*3.5) - len(question) - 20
+	charsNeeded := int(float64(targetTokens)*charsPerToken) - len(question) - paddingOverhead
 	if charsNeeded < 0 {
 		return question
 	}
-
-	seed := "The transformer architecture relies on self-attention mechanisms that allow each token in a sequence to attend to every other token, enabling the model to capture long-range dependencies efficiently. "
+	seed := "The transformer architecture relies on self-attention mechanisms " +
+		"that allow each token in a sequence to attend to every other token, " +
+		"enabling the model to capture long-range dependencies efficiently. "
 	var sb strings.Builder
 	for sb.Len() < charsNeeded {
 		sb.WriteString(seed)
 	}
+
 	return sb.String()[:charsNeeded] + "\n\n" + question
 }

--- a/cmd/vllm-bench/sweep.go
+++ b/cmd/vllm-bench/sweep.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math"
 	"os"
 	"strconv"
 	"strings"
@@ -14,7 +15,12 @@ type sweepPoint struct {
 	targetTokens     int
 	promptTokens     int
 	completionTokens int
-	latency          time.Duration
+	avgLatency       time.Duration
+	minLatency       time.Duration
+	maxLatency       time.Duration
+	avgTokPerSec     float64
+	minTokPerSec     float64
+	maxTokPerSec     float64
 }
 
 func parseSweepSizes(s string) []int {
@@ -41,20 +47,25 @@ func runSweep(ctx context.Context, baseURL string, cfg config, sizes []int) {
 			break
 		}
 
-	_, _ = fmt.Fprintf(os.Stdout, "context ~%dk tokens ... ", target/tokensPerK)
+		_, _ = fmt.Fprintf(os.Stdout, "context ~%dk tokens ... ", target/tokensPerK)
 
-	sweepPoint, ok := measureSweepPoint(ctx, baseURL, cfg, target)
-	if !ok {
-		_, _ = fmt.Fprintln(os.Stdout, "all requests failed, skipping")
+		sweepPoint, ok := measureSweepPoint(ctx, baseURL, cfg, target)
+		if !ok {
+			_, _ = fmt.Fprintln(os.Stdout, "all requests failed, skipping")
 
-		continue
-	}
+			continue
+		}
 
 		results = append(results, sweepPoint)
-		_, _ = fmt.Fprintf(os.Stdout, "prompt=%d  lat=%s  tok/s=%.1f\n",
+		_, _ = fmt.Fprintf(os.Stdout,
+			"prompt=%d  lat min=%s avg=%s max=%s  tok/s min=%.1f avg=%.1f max=%.1f\n",
 			sweepPoint.promptTokens,
-			sweepPoint.latency.Round(time.Millisecond),
-			float64(sweepPoint.completionTokens)/sweepPoint.latency.Seconds(),
+			sweepPoint.minLatency.Round(time.Millisecond),
+			sweepPoint.avgLatency.Round(time.Millisecond),
+			sweepPoint.maxLatency.Round(time.Millisecond),
+			sweepPoint.minTokPerSec,
+			sweepPoint.avgTokPerSec,
+			sweepPoint.maxTokPerSec,
 		)
 	}
 
@@ -70,9 +81,16 @@ func runSweep(ctx context.Context, baseURL string, cfg config, sizes []int) {
 func measureSweepPoint(ctx context.Context, baseURL string, cfg config, target int) (sweepPoint, bool) {
 	prompt := paddedPrompt(target)
 
-	var totalLat time.Duration
-
-	var totalPrompt, totalCompletion, succeeded int
+	var (
+		totalLat        time.Duration
+		minLat          = time.Duration(math.MaxInt64)
+		maxLat          time.Duration
+		totalPrompt     int
+		totalCompletion int
+		succeeded       int
+		minTok          = math.MaxFloat64
+		maxTok          float64
+	)
 
 	for sweepIdx := range cfg.sweepReqs {
 		if ctx.Err() != nil {
@@ -88,6 +106,24 @@ func measureSweepPoint(ctx context.Context, baseURL string, cfg config, target i
 			continue
 		}
 
+		tok := float64(result.completionTokens) / result.latency.Seconds()
+
+		if result.latency < minLat {
+			minLat = result.latency
+		}
+
+		if result.latency > maxLat {
+			maxLat = result.latency
+		}
+
+		if tok < minTok {
+			minTok = tok
+		}
+
+		if tok > maxTok {
+			maxTok = tok
+		}
+
 		totalLat += result.latency
 		totalPrompt += result.promptTokens
 		totalCompletion += result.completionTokens
@@ -98,17 +134,33 @@ func measureSweepPoint(ctx context.Context, baseURL string, cfg config, target i
 		return sweepPoint{}, false
 	}
 
+	return buildSweepPoint(target, totalPrompt, totalCompletion, succeeded, totalLat, minLat, maxLat, minTok, maxTok), true
+}
+
+func buildSweepPoint(
+	target, totalPrompt, totalCompletion, succeeded int,
+	totalLat, minLat, maxLat time.Duration,
+	minTok, maxTok float64,
+) sweepPoint {
+	avgLat := totalLat / time.Duration(succeeded)
+	avgCompletion := totalCompletion / succeeded
+
 	return sweepPoint{
 		targetTokens:     target,
 		promptTokens:     totalPrompt / succeeded,
-		completionTokens: totalCompletion / succeeded,
-		latency:          totalLat / time.Duration(succeeded),
-	}, true
+		completionTokens: avgCompletion,
+		avgLatency:       avgLat,
+		minLatency:       minLat,
+		maxLatency:       maxLat,
+		avgTokPerSec:     float64(avgCompletion) / avgLat.Seconds(),
+		minTokPerSec:     minTok,
+		maxTokPerSec:     maxTok,
+	}
 }
 
 // waitForCapacity blocks until vLLM's waiting queue has room or the context is cancelled.
 func waitForCapacity(ctx context.Context, baseURL string, cfg config) {
-	waitLoop:
+waitLoop:
 	for {
 		snap, err := scrapeMetrics(baseURL + "/metrics")
 		if err != nil || snap.waiting < float64(cfg.maxQueue) {
@@ -124,9 +176,14 @@ func waitForCapacity(ctx context.Context, baseURL string, cfg config) {
 }
 
 func printSweepCharts(results []sweepPoint) {
-	labels := make([]string, len(results))
-	latencies := make([]float64, len(results))
-	throughputs := make([]float64, len(results))
+	numResults := len(results)
+	labels := make([]string, numResults)
+	minLat := make([]float64, numResults)
+	avgLat := make([]float64, numResults)
+	maxLat := make([]float64, numResults)
+	minTok := make([]float64, numResults)
+	avgTok := make([]float64, numResults)
+	maxTok := make([]float64, numResults)
 
 	for idx, result := range results {
 		k := result.promptTokens / tokensPerK
@@ -136,14 +193,18 @@ func printSweepCharts(results []sweepPoint) {
 			labels[idx] = fmt.Sprintf("%dk", k)
 		}
 
-		latencies[idx] = result.latency.Seconds()
-		throughputs[idx] = float64(result.completionTokens) / result.latency.Seconds()
+		minLat[idx] = result.minLatency.Seconds()
+		avgLat[idx] = result.avgLatency.Seconds()
+		maxLat[idx] = result.maxLatency.Seconds()
+		minTok[idx] = result.minTokPerSec
+		avgTok[idx] = result.avgTokPerSec
+		maxTok[idx] = result.maxTokPerSec
 	}
 
 	_, _ = fmt.Fprintln(os.Stdout)
-	_, _ = fmt.Fprintln(os.Stdout, lineChart("Context window vs latency (s)", labels, latencies, "s"))
+	_, _ = fmt.Fprintln(os.Stdout, errorBarChart("Context window vs latency (s)", labels, minLat, avgLat, maxLat))
 	_, _ = fmt.Fprintln(os.Stdout)
-	_, _ = fmt.Fprintln(os.Stdout, lineChart("Context window vs throughput (tok/s)", labels, throughputs, "tok/s"))
+	_, _ = fmt.Fprintln(os.Stdout, errorBarChart("Context window vs throughput (tok/s)", labels, minTok, avgTok, maxTok))
 }
 
 // paddedPrompt returns a prompt whose token count is approximately targetTokens.

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,11 @@ module github.com/nicklasfrahm-dev/platform
 go 1.25.0
 
 require (
+	github.com/guptarohit/asciigraph v0.9.0
 	github.com/nicklasfrahm-dev/appkit v0.2.2
 	github.com/spf13/cobra v1.10.2
 	go.uber.org/zap v1.27.1
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.35.3
 	k8s.io/apimachinery v0.35.3
 	k8s.io/client-go v0.35.3
@@ -21,7 +23,6 @@ require (
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/guptarohit/asciigraph v0.9.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -43,7 +44,6 @@ require (
 	google.golang.org/protobuf v1.36.8 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/guptarohit/asciigraph v0.9.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 h1:BHT72Gu3keYf3ZEu2J
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/guptarohit/asciigraph v0.9.0 h1:MvCSRRVkT2XvU1IO6n92o7l7zqx1DiFaoszOUZQztbY=
+github.com/guptarohit/asciigraph v0.9.0/go.mod h1:dYl5wwK4gNsnFf9Zp+l06rFiDZ5YtXM6x7SRWZ3KGag=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=


### PR DESCRIPTION
This PR adds a token throughput benchmark CLI for vLLM.

```
$ ./bin/vllm-bench sweep --sizes 1024,4096,16384,32768,65536 --requests 100
pod: llm-predictor-6c4f5bfd67-6d5bb
port-forward ready on localhost:18000

sweep: 5 context sizes, 100 requests each, 128 output tokens

context ~1k tokens ...
  prompt=622
  lat min=284ms avg=316ms max=398ms
  tok/s min=70.3 avg=98.0 max=102.9
context ~4k tokens ...
  prompt=2448
  lat min=308ms avg=358ms max=602ms
  tok/s min=56.5 avg=95.0 max=98.9
context ~16k tokens ...
  prompt=9760
  lat min=351ms avg=445ms max=1.791s
  tok/s min=19.0 avg=81.0 max=87.4
context ~32k tokens ...
  prompt=19508
  lat min=364ms avg=518ms max=2.961s
  tok/s min=11.8 avg=69.5 max=77.6
context ~64k tokens ...
  prompt=39007
  lat min=438ms avg=684ms max=7.751s
  tok/s min=4.9 avg=51.2 max=63.6

7.75 ┤                                                           │
6.92 ┤                                                           │
6.09 ┤                                                           │
5.26 ┤                                                           │
4.43 ┤                                                           │
3.60 ┤                                                           │
2.77 ┤                                            │              │
1.94 ┤                             │              │              │
1.11 ┤                             │              │              │
0.28 ┤*             *              *              *              *
                  Context window vs latency (s)
      622t             2k             9k            19k            38k

102.94 ┤*             │
 92.04 ┤│             *              │
 81.15 ┤│             │              *              │
 70.26 ┤│             │              │              *
 59.37 ┤              │              │              │              │
 48.47 ┤                             │              │              *
 37.58 ┤                             │              │              │
 26.69 ┤                             │              │              │
 15.80 ┤                             │              │              │
  4.90 ┤                                                           │
                Context window vs throughput (tok/s)
        622t             2k             9k            19k            38k
```