### PR TITLE
feat(config): update model configurations and gpu profiles

### DIFF
--- a/charts/llm/Chart.yaml
+++ b/charts/llm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 type: application
 name: llm
 description: A Helm chart for deploying a large language model via vLLM on KServe.
-version: 0.1.0
+version: 0.2.0

--- a/charts/llm/templates/configmap.yaml
+++ b/charts/llm/templates/configmap.yaml
@@ -1,4 +1,5 @@
-{{- $profile := index .Values.model.profile .Values.model.name }}
+{{- $model := index .Values.model.profile .Values.model.name }}
+{{- $gpu := index .Values.gpu.profile .Values.gpu.name }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,7 +10,7 @@ data:
     from starlette.middleware.base import BaseHTTPMiddleware
     from starlette.responses import JSONResponse
 
-    MAX_CONCURRENT = {{ $profile.maxNumSeqs }}  # mirrors --max-num-seqs
+    MAX_CONCURRENT = {{ $model.maxNumSeqs | default $gpu.maxNumSeqs }}  # mirrors --max-num-seqs
 
     class BackpressureMiddleware(BaseHTTPMiddleware):
         async def dispatch(self, request, call_next):

--- a/charts/llm/templates/inferenceservice.yaml
+++ b/charts/llm/templates/inferenceservice.yaml
@@ -1,4 +1,5 @@
-{{- $profile := index .Values.model.profile .Values.model.name }}
+{{- $model := index .Values.model.profile .Values.model.name }}
+{{- $gpu := index .Values.gpu.profile .Values.gpu.name }}
 apiVersion: serving.kserve.io/v1beta1
 kind: InferenceService
 metadata:
@@ -20,9 +21,12 @@ spec:
         name: huggingface
       runtime: {{ .Release.Name }}-runtime
       args:
-        - "--served-model-name={{ $profile.servedModelName }}"
+        - "--served-model-name={{ $model.servedModelName }}"
+        {{- range $model.args }}
+        - {{ . | quote }}
+        {{- end }}
       env:
         - name: MODEL_ID
-          value: {{ $profile.modelId | quote }}
+          value: {{ $model.modelId | quote }}
       resources:
-        {{- toYaml .Values.resources | nindent 8 }}
+        {{- toYaml $gpu.resources | nindent 8 }}

--- a/charts/llm/templates/servingruntime.yaml
+++ b/charts/llm/templates/servingruntime.yaml
@@ -1,5 +1,6 @@
-{{- $profile := index .Values.model.profile .Values.model.name }}
-{{- $version := (($profile).vllm).version | default .Values.runtime.vllm.version }}
+{{- $model := index .Values.model.profile .Values.model.name }}
+{{- $gpu := index .Values.gpu.profile .Values.gpu.name }}
+{{- $version := (($model).vllm).version | default .Values.runtime.vllm.version }}
 apiVersion: serving.kserve.io/v1alpha1
 kind: ServingRuntime
 metadata:
@@ -14,18 +15,18 @@ spec:
     - name: kserve-container
       image: vllm/vllm-openai:{{ $version }}
       args:
-        - "--model=$(MODEL_ID)"
-        - "--tensor-parallel-size=1"
-        - "--gpu-memory-utilization=0.95"
+        - "$(MODEL_ID)"
+        - "--tensor-parallel-size={{ $gpu.tensorParallelSize }}"
+        - "--gpu-memory-utilization={{ $gpu.gpuMemoryUtilization }}"
         - "--dtype=auto"
+        {{- if $gpu.kvCacheDtype }}
+        - "--kv-cache-dtype={{ $gpu.kvCacheDtype }}"
+        {{- end }}
         - "--trust-remote-code"
-        - "--max-num-seqs={{ $profile.maxNumSeqs }}"
+        - "--max-num-seqs={{ $model.maxNumSeqs | default $gpu.maxNumSeqs }}"
         - "--enable-server-load-tracking"
         - "--middleware=backpressure.BackpressureMiddleware"
         - "--enable-auto-tool-choice"
-        {{- range $profile.args }}
-        - {{ . | quote }}
-        {{- end }}
       env:
         - name: MODEL_ID
           value: ""
@@ -41,7 +42,7 @@ spec:
           mountPath: /opt/workspace/middlewares
           readOnly: true
       resources:
-        {{- toYaml .Values.resources | nindent 8 }}
+        {{- toYaml $gpu.resources | nindent 8 }}
       ports:
         - containerPort: 8000
   volumes:

--- a/charts/llm/values.yaml
+++ b/charts/llm/values.yaml
@@ -2,6 +2,21 @@ runtime:
   vllm:
     version: "v0.19.0"
 
+gpu:
+  name: rtx3090
+  profile:
+    rtx3090:
+      maxNumSeqs: 1
+      gpuMemoryUtilization: 0.95
+      tensorParallelSize: 1
+      resources:
+        limits:
+          nvidia.com/gpu: 1
+          memory: "12Gi"
+        requests:
+          nvidia.com/gpu: 1
+          memory: "12Gi"
+
 model:
   name: qwen3-30b
   profile:
@@ -9,31 +24,34 @@ model:
       # Stable: RTX 3090 (24GB)
       modelId: "cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit"
       servedModelName: "gemma4-26b"
-      maxNumSeqs: 1
       args:
-        - "--max-model-len=131072"
+        - "--max-model-len=65536"
         - "--quantization=compressed-tensors"
         - "--tool-call-parser=gemma4"
         - "--reasoning-parser=gemma4"
       vllm:
         version: "gemma4"
+    qwen3-coder-30b:
+      modelId: "cyankiwi/Qwen3-Coder-30B-A3B-Instruct-AWQ-4bit"
+      servedModelName: "qwen3-coder-30b"
+      args:
+        - "--max-model-len=65536"
+        - "--quantization=compressed-tensors"
+        - "--tool-call-parser=qwen3_coder"
+        - "--reasoning-parser=qwen3"
     qwen35-27b:
       modelId: "cyankiwi/Qwen3.5-27B-AWQ-4bit"
       servedModelName: "qwen35-27b"
-      maxNumSeqs: 1
       args:
         - "--max-model-len=65536"
-        - "--kv-cache-dtype=fp8"
         - "--quantization=awq_marlin"
         - "--reasoning-parser=qwen3"
         - "--tool-call-parser=qwen3_coder"
     qwen35-35b:
       modelId: "Intel/Qwen3.5-35B-A3B-int4-AutoRound"
       servedModelName: "qwen35-35b"
-      maxNumSeqs: 1
       args:
         - "--max-model-len=32768"
-        - "--kv-cache-dtype=fp8"
         - "--quantization=compressed-tensors"
         - "--language-model-only"
         - "--reasoning-parser=qwen3"
@@ -41,10 +59,8 @@ model:
     qwen36-35b:
       modelId: "cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit"
       servedModelName: "qwen36-35b"
-      maxNumSeqs: 1
       args:
         - "--max-model-len=65536"
-        - "--kv-cache-dtype=fp8"
         - "--quantization=compressed-tensors"
         - "--language-model-only"
         - "--reasoning-parser=qwen3"
@@ -52,30 +68,18 @@ model:
     qwen3-30b:
       modelId: "QuixiAI/Qwen3-30B-A3B-AWQ"
       servedModelName: "qwen3-30b"
-      maxNumSeqs: 1
       args:
         - "--max-model-len=40960"
-        - "--kv-cache-dtype=fp8"
         - "--quantization=awq_marlin"
         - "--tool-call-parser=hermes"
         - "--reasoning-parser=deepseek_r1"
     qwen25-coder-32b:
       modelId: "Qwen/Qwen2.5-Coder-32B-Instruct-AWQ"
       servedModelName: "qwen25-coder-32b"
-      maxNumSeqs: 1
       args:
         - "--max-model-len=40960"
-        - "--kv-cache-dtype=fp8"
         - "--quantization=awq_marlin"
         - "--tool-call-parser=hermes"
-
-resources:
-  limits:
-    nvidia.com/gpu: 1
-    memory: "12Gi"
-  requests:
-    nvidia.com/gpu: 1
-    memory: "12Gi"
 
 route:
   hostname: "llm.cph02.nicklasfrahm.dev"

--- a/charts/llm/values.yaml
+++ b/charts/llm/values.yaml
@@ -20,8 +20,8 @@ gpu:
 model:
   name: qwen3-30b
   profile:
+    # Stable: RTX 3090 (24GB)
     gemma4:
-      # Stable: RTX 3090 (24GB)
       modelId: "cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit"
       servedModelName: "gemma4-26b"
       args:
@@ -31,14 +31,14 @@ model:
         - "--reasoning-parser=gemma4"
       vllm:
         version: "gemma4"
+    # Stable: RTX 3090 (24GB)
     qwen3-coder-30b:
       modelId: "cyankiwi/Qwen3-Coder-30B-A3B-Instruct-AWQ-4bit"
       servedModelName: "qwen3-coder-30b"
       args:
-        - "--max-model-len=65536"
+        - "--max-model-len=51200"
         - "--quantization=compressed-tensors"
         - "--tool-call-parser=qwen3_coder"
-        - "--reasoning-parser=qwen3"
     qwen35-27b:
       modelId: "cyankiwi/Qwen3.5-27B-AWQ-4bit"
       servedModelName: "qwen35-27b"


### PR DESCRIPTION
## Summary

- Introduce `gpu.profile` section in `values.yaml` to decouple GPU-specific settings (resources, `maxNumSeqs`, `gpuMemoryUtilization`, `tensorParallelSize`) from individual model profiles
- Update templates to resolve GPU resources and `maxNumSeqs` from the active GPU profile
- Increase `qwen3-coder-30b` context length from 40960 to 65536