### PR TITLE
fix(charts): correct CNPG secret and service name to include -cluster suffix

### DIFF
--- a/deploy/services/grafana/20-cluster-prd-cph02.yml
+++ b/deploy/services/grafana/20-cluster-prd-cph02.yml
@@ -19,7 +19,7 @@ grafana:
     GF_DATABASE_PASSWORD:
       valueFrom:
         secretKeyRef:
-          name: grafana-postgres-app
+          name: grafana-postgres-cluster-app
           key: password
   grafana.ini:
     server:
@@ -27,7 +27,7 @@ grafana:
       root_url: https://grafana.nicklasfrahm.dev
     database:
       type: postgres
-      host: grafana-postgres-rw.platform:5432
+      host: grafana-postgres-cluster-rw.platform:5432
       name: app
       user: app
       password: ${GF_DATABASE_PASSWORD}


### PR DESCRIPTION
## Summary

- Fix Grafana database secret reference from `grafana-postgres-app` to `grafana-postgres-cluster-app`
- Fix Grafana database host from `grafana-postgres-rw` to `grafana-postgres-cluster-rw`

The CNPG cluster chart appends `-cluster` to the release name via its `fullname` helper, so all generated resources (Cluster CR, services, secrets) carry that suffix.