### PR TITLE
fix(charts): correct Grafana database secret name and env var injection

### DIFF
--- a/deploy/services/grafana/20-cluster-prd-cph02.yml
+++ b/deploy/services/grafana/20-cluster-prd-cph02.yml
@@ -15,12 +15,11 @@ grafana:
   persistence:
     enabled: true
     size: 10Gi
-  env:
+  envValueFrom:
     GF_DATABASE_PASSWORD:
-      valueFrom:
-        secretKeyRef:
-          name: grafana-postgres-cluster-app
-          key: password
+      secretKeyRef:
+        name: grafana-postgres-cluster-app
+        key: password
   grafana.ini:
     server:
       domain: grafana.nicklasfrahm.dev


### PR DESCRIPTION
## Summary

- Fix secret and service names from `grafana-postgres-*` to `grafana-postgres-cluster-*` — the CNPG cluster chart appends `-cluster` via its `fullname` helper
- Fix database password injection from `env` to `envValueFrom` — the Grafana chart only supports `valueFrom` references under `envValueFrom`, not `env`