### PR TITLE
fix(charts): correct Grafana database wiring and persistence storage class

### DIFF
--- a/deploy/services/grafana/20-cluster-prd-cph02.yml
+++ b/deploy/services/grafana/20-cluster-prd-cph02.yml
@@ -15,6 +15,7 @@ grafana:
   persistence:
     enabled: true
     size: 10Gi
+    storageClassName: ceph-bucket
   envValueFrom:
     GF_DATABASE_PASSWORD:
       secretKeyRef:


### PR DESCRIPTION
## Summary

- Fix secret and service names from `grafana-postgres-*` to `grafana-postgres-cluster-*` — the CNPG cluster chart appends `-cluster` via its `fullname` helper
- Fix database password injection from `env` to `envValueFrom` — the Grafana chart only supports `valueFrom` references under `envValueFrom`
- Set Grafana persistence storage class to `ceph-bucket`