### PR TITLE
fix(charts): tune PG counts and remove unused Grafana persistence for prd-cph02

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,12 @@ When you encounter an error:
 
 ---
 
+## KUBERNETES RESOURCES
+
+Always set `limits` equal to `requests` for both CPU and memory on every container. This prevents memory overcommit and ensures pods get the Guaranteed QoS class.
+
+---
+
 ## GO SPECIFICS
 
 - **Idiomatic Go**: Follow table-driven tests, explicit error wrapping, and interface-first design.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,8 @@ When you encounter an error:
 
 ## KUBERNETES RESOURCES
 
-Always set `limits` equal to `requests` for both CPU and memory on every container. This prevents memory overcommit and ensures pods get the Guaranteed QoS class.
+- **Memory**: `limits` must equal `requests` to prevent memory overcommit.
+- **CPU**: set `requests` only, never `limits`. CPU limits cause throttling without preventing overcommit.
 
 ---
 

--- a/charts/rook-ceph-cluster/values.yaml
+++ b/charts/rook-ceph-cluster/values.yaml
@@ -17,12 +17,10 @@ rook-ceph-cluster:
         - name: pg_autoscaler
           enabled: true
 
-    # enable the ceph dashboard for viewing cluster status
     dashboard:
       enabled: true
       ssl: false
 
-    # Network configuration, see: https://github.com/rook/rook/blob/master/Documentation/CRDs/Cluster/ceph-cluster-crd.md#network-configuration-settings
     network:
       connections:
         encryption:
@@ -31,13 +29,85 @@ rook-ceph-cluster:
           enabled: true
         requireMsgr2: true
 
-    # enable log collector, daemons will log on files and rotate
     logCollector:
       enabled: false
 
-    # The option to automatically remove OSDs that are out and are safe to destroy.
     removeOSDsIfOutAndSafeToRemove: true
 
     storage:
       config:
         encryptedDevice: true
+
+  # pg_num=32 keeps initial PGs well under the 250/OSD warning threshold on a
+  # 3-disk cluster; the pg_autoscaler will scale up as data grows.
+  cephBlockPools:
+    - name: ceph-blockpool
+      spec:
+        failureDomain: host
+        replicated:
+          size: 3
+        parameters:
+          pg_num: "32"
+      storageClass:
+        enabled: true
+        name: ceph-block
+        isDefault: true
+        reclaimPolicy: Delete
+        allowVolumeExpansion: true
+        volumeBindingMode: "Immediate"
+        parameters:
+          imageFormat: "2"
+          imageFeatures: layering
+          csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
+          csi.storage.k8s.io/provisioner-secret-namespace: "{{ .Release.Namespace }}"
+          csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
+          csi.storage.k8s.io/controller-expand-secret-namespace: "{{ .Release.Namespace }}"
+          csi.storage.k8s.io/controller-publish-secret-name: rook-csi-rbd-provisioner
+          csi.storage.k8s.io/controller-publish-secret-namespace: "{{ .Release.Namespace }}"
+          csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
+          csi.storage.k8s.io/node-stage-secret-namespace: "{{ .Release.Namespace }}"
+          csi.storage.k8s.io/fstype: ext4
+
+  cephFileSystems:
+    - name: ceph-filesystem
+      spec:
+        metadataPool:
+          replicated:
+            size: 3
+          parameters:
+            pg_num: "32"
+        dataPools:
+          - failureDomain: host
+            replicated:
+              size: 3
+            name: data0
+            parameters:
+              pg_num: "32"
+        metadataServer:
+          activeCount: 1
+          activeStandby: true
+          resources:
+            limits:
+              memory: "4Gi"
+            requests:
+              cpu: "1000m"
+              memory: "4Gi"
+          priorityClassName: system-cluster-critical
+      storageClass:
+        enabled: true
+        isDefault: false
+        name: ceph-filesystem
+        pool: data0
+        reclaimPolicy: Delete
+        allowVolumeExpansion: true
+        volumeBindingMode: "Immediate"
+        parameters:
+          csi.storage.k8s.io/provisioner-secret-name: rook-csi-cephfs-provisioner
+          csi.storage.k8s.io/provisioner-secret-namespace: "{{ .Release.Namespace }}"
+          csi.storage.k8s.io/controller-expand-secret-name: rook-csi-cephfs-provisioner
+          csi.storage.k8s.io/controller-expand-secret-namespace: "{{ .Release.Namespace }}"
+          csi.storage.k8s.io/controller-publish-secret-name: rook-csi-cephfs-provisioner
+          csi.storage.k8s.io/controller-publish-secret-namespace: "{{ .Release.Namespace }}"
+          csi.storage.k8s.io/node-stage-secret-name: rook-csi-cephfs-node
+          csi.storage.k8s.io/node-stage-secret-namespace: "{{ .Release.Namespace }}"
+          csi.storage.k8s.io/fstype: ext4

--- a/charts/rook-ceph-cluster/values.yaml
+++ b/charts/rook-ceph-cluster/values.yaml
@@ -17,10 +17,12 @@ rook-ceph-cluster:
         - name: pg_autoscaler
           enabled: true
 
+    # enable the ceph dashboard for viewing cluster status
     dashboard:
       enabled: true
       ssl: false
 
+    # Network configuration, see: https://github.com/rook/rook/blob/master/Documentation/CRDs/Cluster/ceph-cluster-crd.md#network-configuration-settings
     network:
       connections:
         encryption:
@@ -29,85 +31,13 @@ rook-ceph-cluster:
           enabled: true
         requireMsgr2: true
 
+    # enable log collector, daemons will log on files and rotate
     logCollector:
       enabled: false
 
+    # The option to automatically remove OSDs that are out and are safe to destroy.
     removeOSDsIfOutAndSafeToRemove: true
 
     storage:
       config:
         encryptedDevice: true
-
-  # pg_num=32 keeps initial PGs well under the 250/OSD warning threshold on a
-  # 3-disk cluster; the pg_autoscaler will scale up as data grows.
-  cephBlockPools:
-    - name: ceph-blockpool
-      spec:
-        failureDomain: host
-        replicated:
-          size: 3
-        parameters:
-          pg_num: "32"
-      storageClass:
-        enabled: true
-        name: ceph-block
-        isDefault: true
-        reclaimPolicy: Delete
-        allowVolumeExpansion: true
-        volumeBindingMode: "Immediate"
-        parameters:
-          imageFormat: "2"
-          imageFeatures: layering
-          csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
-          csi.storage.k8s.io/provisioner-secret-namespace: "{{ .Release.Namespace }}"
-          csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
-          csi.storage.k8s.io/controller-expand-secret-namespace: "{{ .Release.Namespace }}"
-          csi.storage.k8s.io/controller-publish-secret-name: rook-csi-rbd-provisioner
-          csi.storage.k8s.io/controller-publish-secret-namespace: "{{ .Release.Namespace }}"
-          csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
-          csi.storage.k8s.io/node-stage-secret-namespace: "{{ .Release.Namespace }}"
-          csi.storage.k8s.io/fstype: ext4
-
-  cephFileSystems:
-    - name: ceph-filesystem
-      spec:
-        metadataPool:
-          replicated:
-            size: 3
-          parameters:
-            pg_num: "32"
-        dataPools:
-          - failureDomain: host
-            replicated:
-              size: 3
-            name: data0
-            parameters:
-              pg_num: "32"
-        metadataServer:
-          activeCount: 1
-          activeStandby: true
-          resources:
-            limits:
-              memory: "4Gi"
-            requests:
-              cpu: "1000m"
-              memory: "4Gi"
-          priorityClassName: system-cluster-critical
-      storageClass:
-        enabled: true
-        isDefault: false
-        name: ceph-filesystem
-        pool: data0
-        reclaimPolicy: Delete
-        allowVolumeExpansion: true
-        volumeBindingMode: "Immediate"
-        parameters:
-          csi.storage.k8s.io/provisioner-secret-name: rook-csi-cephfs-provisioner
-          csi.storage.k8s.io/provisioner-secret-namespace: "{{ .Release.Namespace }}"
-          csi.storage.k8s.io/controller-expand-secret-name: rook-csi-cephfs-provisioner
-          csi.storage.k8s.io/controller-expand-secret-namespace: "{{ .Release.Namespace }}"
-          csi.storage.k8s.io/controller-publish-secret-name: rook-csi-cephfs-provisioner
-          csi.storage.k8s.io/controller-publish-secret-namespace: "{{ .Release.Namespace }}"
-          csi.storage.k8s.io/node-stage-secret-name: rook-csi-cephfs-node
-          csi.storage.k8s.io/node-stage-secret-namespace: "{{ .Release.Namespace }}"
-          csi.storage.k8s.io/fstype: ext4

--- a/deploy/services/grafana/20-cluster-prd-cph02.yml
+++ b/deploy/services/grafana/20-cluster-prd-cph02.yml
@@ -12,10 +12,6 @@ grafana:
       parentRefs:
         - name: shared-http
           namespace: platform
-  persistence:
-    enabled: true
-    size: 10Gi
-    storageClassName: ceph-filesystem
   envValueFrom:
     GF_DATABASE_PASSWORD:
       secretKeyRef:

--- a/deploy/services/grafana/20-cluster-prd-cph02.yml
+++ b/deploy/services/grafana/20-cluster-prd-cph02.yml
@@ -15,7 +15,7 @@ grafana:
   persistence:
     enabled: true
     size: 10Gi
-    storageClassName: ceph-bucket
+    storageClassName: ceph-filesystem
   envValueFrom:
     GF_DATABASE_PASSWORD:
       secretKeyRef:

--- a/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
+++ b/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
@@ -147,49 +147,7 @@ rook-ceph-cluster:
           # in hyperconverged settings where the volume is mounted on the same node as the osds.
           csi.storage.k8s.io/fstype: ext4
 
-  cephFileSystems:
-    - name: ceph-filesystem
-      spec:
-        metadataPool:
-          replicated:
-            size: 3
-          parameters:
-            pg_num: "32"
-        dataPools:
-          - failureDomain: host
-            replicated:
-              size: 3
-            name: data0
-            parameters:
-              pg_num: "32"
-        metadataServer:
-          activeCount: 1
-          activeStandby: true
-          resources:
-            limits:
-              memory: "1Gi"
-            requests:
-              cpu: "250m"
-              memory: "1Gi"
-          priorityClassName: system-cluster-critical
-      storageClass:
-        enabled: true
-        isDefault: false
-        name: ceph-filesystem
-        pool: data0
-        reclaimPolicy: Delete
-        allowVolumeExpansion: true
-        volumeBindingMode: "Immediate"
-        parameters:
-          csi.storage.k8s.io/provisioner-secret-name: rook-csi-cephfs-provisioner
-          csi.storage.k8s.io/provisioner-secret-namespace: "{{ .Release.Namespace }}"
-          csi.storage.k8s.io/controller-expand-secret-name: rook-csi-cephfs-provisioner
-          csi.storage.k8s.io/controller-expand-secret-namespace: "{{ .Release.Namespace }}"
-          csi.storage.k8s.io/controller-publish-secret-name: rook-csi-cephfs-provisioner
-          csi.storage.k8s.io/controller-publish-secret-namespace: "{{ .Release.Namespace }}"
-          csi.storage.k8s.io/node-stage-secret-name: rook-csi-cephfs-node
-          csi.storage.k8s.io/node-stage-secret-namespace: "{{ .Release.Namespace }}"
-          csi.storage.k8s.io/fstype: ext4
+  cephFileSystems: []
 
   # -- A list of CephObjectStore configurations to deploy
   # @default -- See [below](#ceph-object-stores)

--- a/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
+++ b/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
@@ -167,7 +167,6 @@ rook-ceph-cluster:
           activeStandby: true
           resources:
             limits:
-              cpu: "250m"
               memory: "1Gi"
             requests:
               cpu: "250m"

--- a/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
+++ b/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
@@ -167,7 +167,8 @@ rook-ceph-cluster:
           activeStandby: true
           resources:
             limits:
-              memory: "2Gi"
+              cpu: "250m"
+              memory: "1Gi"
             requests:
               cpu: "250m"
               memory: "1Gi"

--- a/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
+++ b/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
@@ -90,6 +90,8 @@ rook-ceph-cluster:
         failureDomain: host
         replicated:
           size: 3
+        parameters:
+          pg_num: "32"
       storageClass:
         enabled: true
         name: ceph-block
@@ -145,7 +147,49 @@ rook-ceph-cluster:
           # in hyperconverged settings where the volume is mounted on the same node as the osds.
           csi.storage.k8s.io/fstype: ext4
 
-  cephFileSystems: []
+  cephFileSystems:
+    - name: ceph-filesystem
+      spec:
+        metadataPool:
+          replicated:
+            size: 3
+          parameters:
+            pg_num: "32"
+        dataPools:
+          - failureDomain: host
+            replicated:
+              size: 3
+            name: data0
+            parameters:
+              pg_num: "32"
+        metadataServer:
+          activeCount: 1
+          activeStandby: true
+          resources:
+            limits:
+              memory: "4Gi"
+            requests:
+              cpu: "1000m"
+              memory: "4Gi"
+          priorityClassName: system-cluster-critical
+      storageClass:
+        enabled: true
+        isDefault: false
+        name: ceph-filesystem
+        pool: data0
+        reclaimPolicy: Delete
+        allowVolumeExpansion: true
+        volumeBindingMode: "Immediate"
+        parameters:
+          csi.storage.k8s.io/provisioner-secret-name: rook-csi-cephfs-provisioner
+          csi.storage.k8s.io/provisioner-secret-namespace: "{{ .Release.Namespace }}"
+          csi.storage.k8s.io/controller-expand-secret-name: rook-csi-cephfs-provisioner
+          csi.storage.k8s.io/controller-expand-secret-namespace: "{{ .Release.Namespace }}"
+          csi.storage.k8s.io/controller-publish-secret-name: rook-csi-cephfs-provisioner
+          csi.storage.k8s.io/controller-publish-secret-namespace: "{{ .Release.Namespace }}"
+          csi.storage.k8s.io/node-stage-secret-name: rook-csi-cephfs-node
+          csi.storage.k8s.io/node-stage-secret-namespace: "{{ .Release.Namespace }}"
+          csi.storage.k8s.io/fstype: ext4
 
   # -- A list of CephObjectStore configurations to deploy
   # @default -- See [below](#ceph-object-stores)
@@ -157,10 +201,14 @@ rook-ceph-cluster:
           failureDomain: host
           replicated:
             size: 3
+          parameters:
+            pg_num: "32"
         dataPool:
           failureDomain: host
           replicated:
             size: 3
+          parameters:
+            pg_num: "32"
         preservePoolsOnDelete: true
         gateway:
           port: 80

--- a/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
+++ b/deploy/services/rook-ceph-cluster/20-cluster-prd-cph02.yml
@@ -167,10 +167,10 @@ rook-ceph-cluster:
           activeStandby: true
           resources:
             limits:
-              memory: "4Gi"
+              memory: "2Gi"
             requests:
-              cpu: "1000m"
-              memory: "4Gi"
+              cpu: "250m"
+              memory: "1Gi"
           priorityClassName: system-cluster-critical
       storageClass:
         enabled: true


### PR DESCRIPTION
## Summary

- Set `pg_num=32` on all Ceph pools (block and object store) to keep initial PG counts under the 250 PGs/OSD warning threshold on a 3-disk cluster; the existing `pg_autoscaler` scales up as data grows
- Remove Grafana persistence — all state is in PostgreSQL, the PVC was unused
- Document Kubernetes resource policy in `AGENTS.md`: memory limits must equal requests; CPU must never have limits