### PR TITLE
fix(charts): add groups_attribute_path to Grafana OAuth config

### DIFF
--- a/deploy/services/grafana/20-cluster-prd-cph02.yml
+++ b/deploy/services/grafana/20-cluster-prd-cph02.yml
@@ -40,6 +40,7 @@ grafana:
       auth_url: https://auth.nicklasfrahm.dev/auth
       token_url: https://auth.nicklasfrahm.dev/token
       api_url: https://auth.nicklasfrahm.dev/userinfo
+      groups_attribute_path: groups
       allowed_groups: "nicklasfrahm-dev:platform"
       role_attribute_path: "contains(groups[*], 'nicklasfrahm-dev:platform') && 'Admin' || 'Viewer'"
       role_attribute_strict: true


### PR DESCRIPTION
## Summary

Grafana 10.2+ uses `groups_attribute_path` as a separate lookup specifically for the `allowed_groups` check. Without it the check always fails, producing "user not a member of one of the required groups", even when the `groups` claim is present and correctly used by `role_attribute_path`.