### PR TITLE
fix(charts): add skatd OIDC client to Dex

### DIFF
--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -3,7 +3,7 @@ type: application
 name: dex
 description: Deploy a Dex instance for single sign-on (SSO) and identity management.
 icon: https://dexidp.io/img/logos/dex-glyph-color.png
-version: 1.0.1
+version: 1.0.2
 appVersion: "0.24.0"
 dependencies:
   - name: dex

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -35,6 +35,11 @@ dex:
         public: true
         redirectURIs:
           - "https://grafana.nicklasfrahm.dev/login/generic_oauth"
+      - id: skatd
+        name: "skatd"
+        public: true
+        redirectURIs:
+          - "http://localhost:8080/ui/callback"
   envVars:
     # The GitHub OIDC secrets are manually created using:
     # kubectl create secret generic dex-github --from-literal=GITHUB_CLIENT_ID=<client-id> --from-literal=GITHUB_CLIENT_SECRET=<client-secret>

--- a/deploy/clusters/prd-cph02/platform/dex.yml
+++ b/deploy/clusters/prd-cph02/platform/dex.yml
@@ -1,2 +1,2 @@
 chart: dex
-tag: 1.0.1
+tag: 1.0.2


### PR DESCRIPTION
Adds a `skatd` public OIDC client to the Dex configuration for prd-cph02.

Uses `public: true` (no client secret) to support the PKCE flow used by the skatd UI. The `http://localhost:8080/ui/callback` redirect URI covers local development; production redirect URIs can be added once the service is deployed.