### PR TITLE
feat(llm): add and deploy qwen36-35b-mixed profile

### DIFF
--- a/charts/llm/values.yaml
+++ b/charts/llm/values.yaml
@@ -100,6 +100,23 @@ model:
         - "--language-model-only"
         - "--reasoning-parser=qwen3"
         - "--tool-call-parser=qwen3_coder"
+    # Untested: RTX 3090 (24GB). Mixed W4/W8 AutoRound (experts INT4, non-experts INT8).
+    # MTP head included — qwen3_next_mtp speculative decoding possible but not enabled
+    # here due to VRAM pressure. Enable with:
+    #   --speculative-config={"method":"qwen3_next_mtp","num_speculative_tokens":1}
+    # and reduce --max-model-len accordingly if OOM.
+    # Known: infinite-loop risk on some inputs (Intel upstream issue, partially mitigated).
+    qwen36-35b-mixed:
+      modelId: "Intel/Qwen3.6-35B-A3B-int4-mixed-AutoRound"
+      servedModelName: "qwen36-35b-mixed"
+      args:
+        - "--max-model-len=32768"
+        - "--quantization=compressed-tensors"
+        - "--reasoning-parser=qwen3"
+        - "--tool-call-parser=qwen3_coder"
+        - "--enable-chunked-prefill"
+        - "--max-num-batched-tokens=8192"
+        - "--max-cudagraph-capture-size=256"
     # Untested: RTX 3090 (24GB)
     qwen3-30b:
       modelId: "QuixiAI/Qwen3-30B-A3B-AWQ"

--- a/deploy/services/llm/20-cluster-prd-cph02.yml
+++ b/deploy/services/llm/20-cluster-prd-cph02.yml
@@ -1,2 +1,2 @@
 model:
-  name: qwen3-coder-30b
+  name: qwen36-35b-mixed


### PR DESCRIPTION
## Summary

- Adds `qwen36-35b-mixed` model profile to the LLM chart (`Intel/Qwen3.6-35B-A3B-int4-mixed-AutoRound`, mixed W4/W8 AutoRound)
- Deploys it on cph02 by updating `deploy/services/llm/20-cluster-prd-cph02.yml`

## Notes

- Untested on RTX 3090 (24GB) — `--max-model-len=32768` is conservative to leave headroom for KV cache given mixed quantization weights
- MTP head is present in the model; speculative decoding (`qwen3_next_mtp`) is intentionally disabled due to VRAM pressure
- Known upstream issue: infinite-loop risk on some inputs (Intel AutoRound, partially mitigated)

## Test plan

- [ ] Verify pod comes up healthy after merge
- [ ] Confirm inference responds correctly via `llm.cph02.nicklasfrahm.dev`
- [ ] Check VRAM headroom under load — reduce `--max-model-len` if OOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)