### PR TITLE
feat(charts): add monitoring-server chart with Loki and wire Grafana datasource

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -3,7 +3,7 @@ type: application
 name: grafana
 description: Deploy Grafana.
 icon: https://artifacthub.io/image/e54f5816-af00-4cc1-998e-b03de8ba5acd
-version: 0.1.0
+version: 0.1.1
 appVersion: "12.3.1"
 dependencies:
   - repository: https://grafana.github.io/helm-charts

--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -3,7 +3,7 @@ type: application
 name: grafana
 description: Deploy Grafana.
 icon: https://artifacthub.io/image/e54f5816-af00-4cc1-998e-b03de8ba5acd
-version: 0.2.1
+version: 0.2.2
 appVersion: "12.3.1"
 dependencies:
   - repository: https://grafana.github.io/helm-charts

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -1,2 +1,15 @@
 grafana:
   enabled: true
+
+  # Automatically provision the Loki log store (deployed by the
+  # monitoring-server release in the monitoring-system namespace) as a datasource.
+  datasources:
+    datasources.yaml:
+      apiVersion: 1
+      datasources:
+        - name: Loki
+          uid: loki
+          type: loki
+          access: proxy
+          url: http://monitoring-server-loki.monitoring-system:3100
+          isDefault: false

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -1,5 +1,8 @@
 grafana:
   enabled: true
+
+  # Automatically provision the Loki log store (deployed by the
+  # monitoring-server release in the monitoring-system namespace) as a datasource.
   datasources:
     datasources.yaml:
       apiVersion: 1
@@ -9,3 +12,9 @@ grafana:
           access: proxy
           url: http://tempo.monitoring-system:3200
           editable: false
+        - name: Loki
+          uid: loki
+          type: loki
+          access: proxy
+          url: http://monitoring-server-loki.monitoring-system:3100
+          isDefault: false

--- a/charts/monitoring-server/Chart.yaml
+++ b/charts/monitoring-server/Chart.yaml
@@ -1,0 +1,26 @@
+apiVersion: v2
+type: application
+name: monitoring-server
+description: A monolithic Loki log store fronted by an Alloy OTEL gateway.
+icon: https://grafana.com/static/assets/img/blog/loki_logo.png
+version: 0.1.0
+appVersion: "3.6.7"
+dependencies:
+  - repository: https://grafana.github.io/helm-charts
+    name: loki
+    version: 6.55.0
+    condition: loki.enabled
+    tags:
+      - observability
+      - loki
+      - logs
+  - repository: https://grafana.github.io/helm-charts
+    name: alloy
+    # Aliased so the OTEL gateway is configured under the "otel-gateway" key.
+    alias: otel-gateway
+    version: 1.10.0
+    condition: otel-gateway.enabled
+    tags:
+      - observability
+      - alloy
+      - otel

--- a/charts/monitoring-server/artifacthub-repo.yml
+++ b/charts/monitoring-server/artifacthub-repo.yml
@@ -1,0 +1,7 @@
+# References:
+# - https://artifacthub.io/docs/topics/repositories/container-images/#repository-metadata
+# - https://github.com/artifacthub/hub/blob/master/docs/metadata/artifacthub-repo.yml
+repositoryID: ""
+owners:
+  - name: Nicklas Frahm
+    email: nicklas.frahm@gmail.com

--- a/charts/monitoring-server/templates/_helpers.tpl
+++ b/charts/monitoring-server/templates/_helpers.tpl
@@ -1,0 +1,23 @@
+{{/* Name of the Alloy OTEL gateway (matches the aliased "otel-gateway" subchart's fullname). */}}
+{{- define "monitoring-server.gateway" -}}
+{{- printf "%s-otel-gateway" .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/* Hostname for the public OTLP ingest endpoint. */}}
+{{- define "monitoring-server.gateway.host" -}}
+{{- printf "%s.%s" .Values.route.subdomain .Values.platform.domain }}
+{{- end }}
+
+{{/* Selector-style labels for the gateway routing resources. */}}
+{{- define "monitoring-server.gateway.selectorLabels" -}}
+app.kubernetes.io/name: "alloy"
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
+app.kubernetes.io/component: "otel-gateway"
+{{- end }}
+
+{{/* Common labels for the gateway routing resources. */}}
+{{- define "monitoring-server.gateway.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" | quote }}
+{{ include "monitoring-server.gateway.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+{{- end }}

--- a/charts/monitoring-server/templates/httproute.yaml
+++ b/charts/monitoring-server/templates/httproute.yaml
@@ -1,0 +1,31 @@
+{{- if (index .Values "otel-gateway").enabled }}
+{{- range $cluster, $enabled := .Values.auth.clusters }}
+{{- if $enabled }}
+---
+# Header-based route: telemetry tagged "X-Cluster: {{ $cluster }}" is admitted
+# for this cluster and authorized by the matching SecurityPolicy.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "monitoring-server.gateway" $ }}-{{ $cluster }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "monitoring-server.gateway.labels" $ | nindent 4 }}
+spec:
+  hostnames:
+    - {{ include "monitoring-server.gateway.host" $ | quote }}
+  parentRefs:
+    - name: {{ $.Values.route.gateway.name }}
+      namespace: {{ $.Values.route.gateway.namespace }}
+  rules:
+    - matches:
+        - headers:
+            - name: X-Cluster
+              value: {{ $cluster | quote }}
+      backendRefs:
+        # Alloy OTLP/HTTP receiver (see otel-gateway.alloy.extraPorts).
+        - name: {{ include "monitoring-server.gateway" $ }}
+          port: 4318
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/monitoring-server/templates/securitypolicy.yaml
+++ b/charts/monitoring-server/templates/securitypolicy.yaml
@@ -1,0 +1,25 @@
+{{- if (index .Values "otel-gateway").enabled }}
+{{- range $cluster, $enabled := .Values.auth.clusters }}
+{{- if $enabled }}
+---
+# Accept only JWTs signed by cluster "{{ $cluster }}"'s OIDC issuer on its route.
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: {{ include "monitoring-server.gateway" $ }}-{{ $cluster }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "monitoring-server.gateway.labels" $ | nindent 4 }}
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: {{ include "monitoring-server.gateway" $ }}-{{ $cluster }}
+  jwt:
+    providers:
+      - name: {{ $cluster | quote }}
+        remoteJWKS:
+          uri: {{ printf "https://oidc.%s.%s%s" $cluster $.Values.platform.domain $.Values.auth.jwksPath | quote }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/monitoring-server/values.yaml
+++ b/charts/monitoring-server/values.yaml
@@ -1,0 +1,193 @@
+# Platform metadata injected by the ArgoCD ApplicationSet.
+platform:
+  # Base domain, e.g. "nicklasfrahm.dev". Hostnames are derived from this.
+  domain: ""
+
+# Alloy OTEL gateway (upstream grafana/alloy subchart, aliased as "otel-gateway"):
+# the public ingest endpoint that receives OTLP telemetry and forwards logs to Loki.
+# See https://github.com/grafana/alloy/blob/main/operations/helm/charts/alloy/values.yaml
+otel-gateway:
+  enabled: true
+
+  controller:
+    type: deployment
+    replicas: 2
+
+  alloy:
+    # Expose the OTLP receiver ports (the chart only opens 12345 by default).
+    extraPorts:
+      - name: otlp-grpc
+        port: 4317
+        targetPort: 4317
+        protocol: TCP
+      - name: otlp-http
+        port: 4318
+        targetPort: 4318
+        protocol: TCP
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "256Mi"
+      limits:
+        memory: "256Mi"
+    configMap:
+      content: |
+        // OTLP gateway: accept telemetry over gRPC (4317) and HTTP (4318) and
+        // forward logs to the in-cluster Loki store via its native OTLP endpoint.
+        otelcol.receiver.otlp "gateway" {
+          grpc {
+            endpoint = "0.0.0.0:4317"
+          }
+          http {
+            endpoint = "0.0.0.0:4318"
+          }
+          output {
+            // Only logs have a backend (Loki); metrics and traces are dropped.
+            logs = [otelcol.processor.batch.gateway.input]
+          }
+        }
+
+        otelcol.processor.batch "gateway" {
+          output {
+            logs = [otelcol.exporter.otlphttp.loki.input]
+          }
+        }
+
+        otelcol.exporter.otlphttp "loki" {
+          client {
+            endpoint = "http://monitoring-server-loki:3100/otlp"
+          }
+        }
+
+# Public HTTPRoute that exposes the Alloy OTLP/HTTP receiver. One route is
+# rendered per enabled entry in auth.clusters, each matched on the X-Cluster
+# header and guarded by its own SecurityPolicy. The hostname is built as
+# "<subdomain>.<platform.domain>".
+route:
+  subdomain: otel
+  gateway:
+    name: public-web-gateway
+    namespace: platform
+
+auth:
+  # Path appended to https://oidc.<cluster>.<platform.domain> for the JWKS.
+  # NOTE: the llm chart uses "/openid/v1/jwks"; reconcile if they must match.
+  jwksPath: "/v1/openid/jwks"
+  # Each "true" entry admits a cluster: it creates an HTTPRoute matching
+  # "X-Cluster: <cluster>" plus a SecurityPolicy that accepts JWTs from
+  # https://oidc.<cluster>.<platform.domain><jwksPath>.
+  clusters: {}
+  # cph02: true
+
+# Values for the upstream grafana/loki subchart.
+# See https://github.com/grafana/loki/blob/main/production/helm/loki/values.yaml
+loki:
+  enabled: true
+
+  # Run Loki as a monolith: every instance runs the full `-target=all` stack
+  # and they coordinate via a memberlist ring backed by shared object storage.
+  deploymentMode: SingleBinary
+
+  # The "loki" block holds the rendered Loki application config.
+  loki:
+    auth_enabled: false
+
+    commonConfig:
+      # Must be <= singleBinary.replicas for highly-available writes.
+      replication_factor: 3
+
+    # Single TSDB schema backed by the object bucket.
+    schemaConfig:
+      configs:
+        - from: "2024-04-01"
+          store: tsdb
+          object_store: s3
+          schema: v13
+          index:
+            prefix: index_
+            period: 24h
+
+    # Chunks and the ruler live in the Ceph object bucket. The ${...} values are
+    # populated at runtime from the object bucket claim's generated ConfigMap and
+    # Secret (wired in via singleBinary.extraEnvFrom + -config.expand-env=true).
+    storage:
+      type: s3
+      bucketNames:
+        chunks: ${BUCKET_NAME}
+        ruler: ${BUCKET_NAME}
+      s3:
+        endpoint: ${BUCKET_HOST}:${BUCKET_PORT}
+        region: ${BUCKET_REGION}
+        accessKeyId: ${AWS_ACCESS_KEY_ID}
+        secretAccessKey: ${AWS_SECRET_ACCESS_KEY}
+        s3ForcePathStyle: true
+        # RGW is reached over plain HTTP inside the cluster.
+        insecure: true
+
+    limits_config:
+      retention_period: 168h # 7 days
+      reject_old_samples: true
+      reject_old_samples_max_age: 168h
+
+    # Enable the compactor to actually delete chunks past the retention period.
+    structuredConfig:
+      compactor:
+        retention_enabled: true
+        delete_request_store: s3
+        working_directory: /var/loki/compactor
+        compaction_interval: 10m
+
+  # The monolithic instances.
+  singleBinary:
+    replicas: 3
+    extraArgs:
+      # Expand ${...} placeholders in the config from the env vars below.
+      - "-config.expand-env=true"
+    extraEnvFrom:
+      # Object bucket claim outputs: BUCKET_HOST/PORT/NAME/REGION (ConfigMap).
+      - configMapRef:
+          name: monitoring-server-logs
+      # Object bucket claim outputs: AWS_ACCESS_KEY_ID/SECRET (Secret).
+      - secretRef:
+          name: monitoring-server-logs
+    persistence:
+      # Local block storage for the WAL and index cache only; chunks go to S3.
+      enabled: true
+      storageClass: ceph-block
+      size: 10Gi
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "512Mi"
+      limits:
+        memory: "512Mi"
+
+  # Disable the simple-scalable / microservice components.
+  write:
+    replicas: 0
+  read:
+    replicas: 0
+  backend:
+    replicas: 0
+
+  # Keep the footprint small: no caches, gateway, canary or test pods.
+  chunksCache:
+    enabled: false
+  resultsCache:
+    enabled: false
+  gateway:
+    enabled: false
+  lokiCanary:
+    enabled: false
+  test:
+    enabled: false
+
+  # Provision the Ceph object bucket that backs long-term log storage.
+  extraObjects:
+    - apiVersion: objectbucket.io/v1alpha1
+      kind: ObjectBucketClaim
+      metadata:
+        name: monitoring-server-logs
+      spec:
+        generateBucketName: monitoring-server-logs
+        storageClassName: ceph-bucket

--- a/deploy/clusters/prd-cph02/monitoring-system/monitoring-server.yml
+++ b/deploy/clusters/prd-cph02/monitoring-system/monitoring-server.yml
@@ -1,0 +1,2 @@
+chart: monitoring-server
+tag: 0.1.0

--- a/deploy/clusters/prd-cph02/platform/grafana.yml
+++ b/deploy/clusters/prd-cph02/platform/grafana.yml
@@ -1,2 +1,2 @@
 chart: grafana
-tag: 0.2.1
+tag: 0.2.2

--- a/deploy/clusters/prd-cph02/platform/grafana.yml
+++ b/deploy/clusters/prd-cph02/platform/grafana.yml
@@ -1,2 +1,2 @@
 chart: grafana
-tag: 0.1.0
+tag: 0.1.1

--- a/deploy/services/argocd-apps/20-cluster-prd-cph02.yml
+++ b/deploy/services/argocd-apps/20-cluster-prd-cph02.yml
@@ -3,3 +3,5 @@ cluster: prd-cph02
 tenants:
   llm:
     enabled: true
+  monitoring-system:
+    enabled: true

--- a/deploy/services/monitoring-server/00-base.yml
+++ b/deploy/services/monitoring-server/00-base.yml
@@ -1,0 +1,2 @@
+# Base values for the monitoring-server release. Cluster admission for the OTEL
+# gateway is configured per cluster in 20-cluster-<cluster>.yml.

--- a/deploy/services/monitoring-server/20-cluster-prd-cph02.yml
+++ b/deploy/services/monitoring-server/20-cluster-prd-cph02.yml
@@ -1,0 +1,5 @@
+# Admit the cph02 cluster: telemetry sent with "X-Cluster: cph02" is authorized
+# against https://oidc.cph02.<platform.domain>/v1/openid/jwks.
+auth:
+  clusters:
+    cph02: true

--- a/deploy/services/public-web-gateway/20-cluster-prd-cph02.yml
+++ b/deploy/services/public-web-gateway/20-cluster-prd-cph02.yml
@@ -8,5 +8,6 @@ gateway:
     - llm.cph02.nicklasfrahm.dev
     - oidc.cph02.nicklasfrahm.dev
     - grafana.nicklasfrahm.dev
+    - otel.nicklasfrahm.dev
   addresses:
     - value: 172.29.0.1


### PR DESCRIPTION
This PR introduces a new monitoring-server Helm chart that bundles Loki and Alloy for log aggregation. It provisions Loki as a Grafana datasource and bumps the grafana chart to version 0.1.1. Additionally, it enables the monitoring-system ArgoCD tenant on prd-cph02 and exposes the OTel endpoint via the public gateway.