### PR TITLE
feat(llm): tune gemma4 vLLM args and add request queue backpressure

### DIFF
--- a/charts/llm/Chart.yaml
+++ b/charts/llm/Chart.yaml
@@ -3,4 +3,4 @@ type: application
 name: llm
 description: A Helm chart for deploying a large language model via vLLM on KServe.
 icon: https://img.icons8.com/ios7/1200/electronic-brain.jpg
-version: 0.3.13
+version: 0.3.14

--- a/charts/llm/Chart.yaml
+++ b/charts/llm/Chart.yaml
@@ -3,4 +3,4 @@ type: application
 name: llm
 description: A Helm chart for deploying a large language model via vLLM on KServe.
 icon: https://img.icons8.com/ios7/1200/electronic-brain.jpg
-version: 0.3.12
+version: 0.3.13

--- a/charts/llm/Chart.yaml
+++ b/charts/llm/Chart.yaml
@@ -3,4 +3,4 @@ type: application
 name: llm
 description: A Helm chart for deploying a large language model via vLLM on KServe.
 icon: https://img.icons8.com/ios7/1200/electronic-brain.jpg
-version: 0.3.14
+version: 0.3.13

--- a/charts/llm/templates/configmap.yaml
+++ b/charts/llm/templates/configmap.yaml
@@ -97,6 +97,7 @@ data:
     from starlette.responses import JSONResponse
 
     MAX_CONCURRENT = {{ $model.maxNumSeqs | default $gpu.maxNumSeqs }}  # mirrors --max-num-seqs
+    MAX_QUEUE = 4
 
     class BackpressureMiddleware(BaseHTTPMiddleware):
         async def dispatch(self, request, call_next):
@@ -107,7 +108,7 @@ data:
                 load = getattr(
                     request.app.state, "server_load_metrics", 0
                 )
-                if load >= MAX_CONCURRENT:
+                if load >= MAX_CONCURRENT or load >= MAX_QUEUE:
                     return JSONResponse(
                         {
                             "error": {

--- a/charts/llm/templates/configmap.yaml
+++ b/charts/llm/templates/configmap.yaml
@@ -97,7 +97,6 @@ data:
     from starlette.responses import JSONResponse
 
     MAX_CONCURRENT = {{ $model.maxNumSeqs | default $gpu.maxNumSeqs }}  # mirrors --max-num-seqs
-    MAX_QUEUE = MAX_CONCURRENT
 
     class BackpressureMiddleware(BaseHTTPMiddleware):
         async def dispatch(self, request, call_next):
@@ -108,7 +107,7 @@ data:
                 load = getattr(
                     request.app.state, "server_load_metrics", 0
                 )
-                if load >= MAX_QUEUE:
+                if load >= MAX_CONCURRENT:
                     return JSONResponse(
                         {
                             "error": {

--- a/charts/llm/templates/configmap.yaml
+++ b/charts/llm/templates/configmap.yaml
@@ -97,7 +97,7 @@ data:
     from starlette.responses import JSONResponse
 
     MAX_CONCURRENT = {{ $model.maxNumSeqs | default $gpu.maxNumSeqs }}  # mirrors --max-num-seqs
-    MAX_QUEUE = 4
+    MAX_QUEUE = MAX_CONCURRENT
 
     class BackpressureMiddleware(BaseHTTPMiddleware):
         async def dispatch(self, request, call_next):
@@ -108,7 +108,7 @@ data:
                 load = getattr(
                     request.app.state, "server_load_metrics", 0
                 )
-                if load >= MAX_CONCURRENT or load >= MAX_QUEUE:
+                if load >= MAX_QUEUE:
                     return JSONResponse(
                         {
                             "error": {

--- a/charts/llm/values.yaml
+++ b/charts/llm/values.yaml
@@ -35,7 +35,7 @@ model:
         - "--quantization=compressed-tensors"
         - "--limit-mm-per-prompt={\"image\": 0, \"video\": 0}"
         - "--max-model-len=180224"
-        - "--max-num-batched-tokens=180224"
+        - "--max-num-batched-tokens=8192"
         - "--enable-chunked-prefill"
     # Stable: RTX 3090 (24GB)
     devstral-small:

--- a/charts/llm/values.yaml
+++ b/charts/llm/values.yaml
@@ -6,7 +6,7 @@ gpu:
   name: rtx3090
   profile:
     rtx3090:
-      maxNumSeqs: 4
+      maxNumSeqs: 1
       gpuMemoryUtilization: 0.985
       tensorParallelSize: 1
       resources:
@@ -24,6 +24,7 @@ model:
     gemma4-26b:
       modelId: "cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit"
       servedModelName: "gemma4-26b"
+      maxNumSeqs: 4
       args:
         # Model capability optimizations.
         - "--chat-template=examples/tool_chat_template_gemma4.jinja"

--- a/charts/llm/values.yaml
+++ b/charts/llm/values.yaml
@@ -6,7 +6,7 @@ gpu:
   name: rtx3090
   profile:
     rtx3090:
-      maxNumSeqs: 1
+      maxNumSeqs: 4
       gpuMemoryUtilization: 0.985
       tensorParallelSize: 1
       resources:
@@ -25,15 +25,17 @@ model:
       modelId: "cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit"
       servedModelName: "gemma4-26b"
       args:
-        - "--max-model-len=180224"
+        # Model capability optimizations.
+        - "--chat-template=examples/tool_chat_template_gemma4.jinja"
         - "--tool-call-parser=gemma4"
         - "--reasoning-parser=gemma4"
-        - "--enable-chunked-prefill"
-        - "--max-num-batched-tokens=8192"
-        - "--chat-template=examples/tool_chat_template_gemma4.jinja"
         - "--default-chat-template-kwargs={\"enable_thinking\": true}"
+        # Memory and performance optimizations.
         - "--quantization=compressed-tensors"
         - "--limit-mm-per-prompt={\"image\": 0, \"video\": 0}"
+        - "--max-model-len=180224"
+        - "--max-num-batched-tokens=180224"
+        - "--enable-chunked-prefill"
     # Stable: RTX 3090 (24GB)
     devstral-small:
       modelId: "cyankiwi/Devstral-Small-2507-AWQ-4bit"


### PR DESCRIPTION
## Summary
- Bump charts/llm chart version to 0.3.13
- Increase maxNumSeqs to 4 for the gemma4 GPU profile
- Reorder/adjust gemma4 vLLM args: align max-model-len and max-num-batched-tokens (180224), keep chunked prefill and chat template settings
- Add MAX_QUEUE threshold to the proxy backpressure middleware so requests are rejected once the queue backs up, not just on concurrent load