### PR TITLE
feat(charts): add jaeger tracing chart and deploy to cph02

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -3,7 +3,7 @@ type: application
 name: grafana
 description: Deploy Grafana.
 icon: https://artifacthub.io/image/e54f5816-af00-4cc1-998e-b03de8ba5acd
-version: 0.1.0
+version: 0.2.0
 appVersion: "12.3.1"
 dependencies:
   - repository: https://grafana.github.io/helm-charts

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -1,2 +1,11 @@
 grafana:
   enabled: true
+  datasources:
+    datasources.yaml:
+      apiVersion: 1
+      datasources:
+        - name: Jaeger
+          type: jaeger
+          access: proxy
+          url: http://jaeger.monitoring-system:16686
+          editable: false

--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -4,7 +4,7 @@ name: jaeger
 description: Deploy Jaeger for distributed tracing with ephemeral, short-retention storage.
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg
 version: 0.1.0
-appVersion: "0.1.0"
+appVersion: "4.11.1"
 dependencies:
   - repository: https://jaegertracing.github.io/helm-charts
     name: jaeger

--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -4,7 +4,7 @@ name: jaeger
 description: Deploy Jaeger for distributed tracing with ephemeral, short-retention storage.
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg
 version: 0.1.0
-appVersion: "2.19.0"
+appVersion: "0.1.0"
 dependencies:
   - repository: https://jaegertracing.github.io/helm-charts
     name: jaeger

--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+type: application
+name: jaeger
+description: Deploy Jaeger for distributed tracing with ephemeral, short-retention storage.
+icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg
+version: 0.1.0
+appVersion: "2.19.0"
+dependencies:
+  - repository: https://jaegertracing.github.io/helm-charts
+    name: jaeger
+    version: 4.11.1
+    condition: jaeger.enabled

--- a/charts/jaeger/templates/securitypolicy.yaml
+++ b/charts/jaeger/templates/securitypolicy.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.jaeger.jaeger.httproute.enabled }}
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: {{ .Values.jaeger.fullnameOverride }}-private-only
+  namespace: {{ .Release.Namespace }}
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: {{ .Values.jaeger.fullnameOverride }}
+  authorization:
+    defaultAction: Deny
+    rules:
+      - name: allow-rfc1918
+        action: Allow
+        principal:
+          clientCIDRs:
+            - 10.0.0.0/8
+            - 172.16.0.0/12
+            - 192.168.0.0/16
+{{- end }}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -1,0 +1,134 @@
+jaeger:
+  enabled: true
+  # Pin the generated resource names so the SecurityPolicy in this chart can
+  # target the HTTPRoute by a known name regardless of the release name.
+  fullnameOverride: "jaeger"
+
+  jaeger:
+    httproute:
+      enabled: true
+      parentRefs:
+        - name: public-web-gateway
+          namespace: platform
+      hostnames:
+        - "jaeger.nicklasfrahm.dev"
+
+    extraVolumes:
+      - name: badger
+        emptyDir:
+          sizeLimit: 256Mi
+    extraVolumeMounts:
+      - name: badger
+        mountPath: /badger
+
+    # Satisfy the restricted PodSecurity standard explicitly, since the
+    # chart's own defaults only set non-root UIDs/GIDs.
+    podSecurityContext:
+      runAsUser: 10001
+      runAsGroup: 10001
+      fsGroup: 10001
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+
+  # Full collector config, mirroring the chart's built-in all-in-one default
+  # (https://github.com/jaegertracing/jaeger/blob/main/cmd/jaeger/internal/all-in-one.yaml),
+  # but swapping the default in-memory backend for Badger on the emptyDir
+  # volume above with a short TTL, since traces only need to survive for the
+  # life of the pod.
+  userconfig:
+    service:
+      extensions: [jaeger_storage, jaeger_query, jaeger_mcp, remote_sampling, healthcheckv2, expvar, zpages]
+      pipelines:
+        traces:
+          receivers: [otlp, jaeger, zipkin]
+          processors: [batch]
+          exporters: [jaeger_storage_exporter]
+      telemetry:
+        resource:
+          service.name: jaeger
+        metrics:
+          level: detailed
+          readers:
+            - pull:
+                exporter:
+                  prometheus:
+                    host: "${env:JAEGER_LISTEN_HOST:-localhost}"
+                    port: 8888
+        logs:
+          level: info
+
+    extensions:
+      jaeger_query:
+        storage:
+          traces: badger_storage
+
+      jaeger_mcp:
+        http:
+          endpoint: "${env:JAEGER_LISTEN_HOST:-localhost}:16687"
+
+      jaeger_storage:
+        backends:
+          badger_storage:
+            badger:
+              ephemeral: false
+              directories:
+                keys: /badger/keys
+                values: /badger/values
+              ttl:
+                spans: 24h
+
+      remote_sampling:
+        file:
+          path:
+          default_sampling_probability: 1
+          reload_interval: 1s
+        http:
+          endpoint: "${env:JAEGER_LISTEN_HOST:-localhost}:5778"
+        grpc:
+          endpoint: "${env:JAEGER_LISTEN_HOST:-localhost}:5779"
+
+      healthcheckv2:
+        use_v2: true
+        http:
+          endpoint: "${env:JAEGER_LISTEN_HOST:-localhost}:13133"
+        grpc:
+
+      expvar:
+        endpoint: "${env:JAEGER_LISTEN_HOST:-localhost}:27777"
+
+      zpages:
+        endpoint: "${env:JAEGER_LISTEN_HOST:-localhost}:27778"
+
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: "${env:JAEGER_LISTEN_HOST:-localhost}:4317"
+          http:
+            endpoint: "${env:JAEGER_LISTEN_HOST:-localhost}:4318"
+
+      jaeger:
+        protocols:
+          grpc:
+            endpoint: "${env:JAEGER_LISTEN_HOST:-localhost}:14250"
+          thrift_http:
+            endpoint: "${env:JAEGER_LISTEN_HOST:-localhost}:14268"
+          thrift_binary:
+            endpoint: "${env:JAEGER_LISTEN_HOST:-localhost}:6832"
+          thrift_compact:
+            endpoint: "${env:JAEGER_LISTEN_HOST:-localhost}:6831"
+
+      zipkin:
+        endpoint: "${env:JAEGER_LISTEN_HOST:-localhost}:9411"
+
+    processors:
+      batch:
+
+    exporters:
+      jaeger_storage_exporter:
+        trace_storage: badger_storage

--- a/deploy/clusters/prd-cph02/monitoring-system/jaeger.yml
+++ b/deploy/clusters/prd-cph02/monitoring-system/jaeger.yml
@@ -1,0 +1,2 @@
+chart: jaeger
+tag: 0.1.0

--- a/deploy/clusters/prd-cph02/platform/grafana.yml
+++ b/deploy/clusters/prd-cph02/platform/grafana.yml
@@ -1,2 +1,2 @@
 chart: grafana
-tag: 0.1.0
+tag: 0.2.0

--- a/deploy/services/argocd-apps/20-cluster-prd-cph02.yml
+++ b/deploy/services/argocd-apps/20-cluster-prd-cph02.yml
@@ -3,3 +3,5 @@ cluster: prd-cph02
 tenants:
   llm:
     enabled: true
+  monitoring-system:
+    enabled: true

--- a/deploy/services/public-web-gateway/20-cluster-prd-cph02.yml
+++ b/deploy/services/public-web-gateway/20-cluster-prd-cph02.yml
@@ -8,5 +8,6 @@ gateway:
     - llm.cph02.nicklasfrahm.dev
     - oidc.cph02.nicklasfrahm.dev
     - grafana.nicklasfrahm.dev
+    - jaeger.nicklasfrahm.dev
   addresses:
     - value: 172.29.0.1


### PR DESCRIPTION
## Summary
- Add a small umbrella chart for Jaeger (`charts/jaeger`) using Badger storage on an `emptyDir` volume with a 24h span TTL, an HTTPRoute restricted to RFC1918 client CIDRs via an Envoy Gateway `SecurityPolicy`, and a restricted-PodSecurity-compliant `securityContext`.
- Deploy Jaeger to a new `monitoring-system` tenant on `prd-cph02` via `argocd-apps`.
- Provision Jaeger as a datasource in the Grafana chart, pointing at the in-cluster Jaeger query service.