### PR TITLE
fix(charts): bump grafana cph02 deploy tag to match chart version

### DIFF
--- a/deploy/clusters/prd-cph02/platform/grafana.yml
+++ b/deploy/clusters/prd-cph02/platform/grafana.yml
@@ -1,2 +1,2 @@
 chart: grafana
-tag: 0.2.0
+tag: 0.2.1


### PR DESCRIPTION
## Summary
- #321 bumped `charts/grafana/Chart.yaml` to `0.2.1` for the Tempo datasource change, but left `deploy/clusters/prd-cph02/platform/grafana.yml`'s `tag: 0.2.0` unbumped
- Since ArgoCD's `targetRevision` is sourced from that `tag` field, cph02 was still pinned to the old chart version without the datasource change