### PR TITLE
fix(charts): enable tempo metrics-generator for TraceQL metrics queries

### DIFF
--- a/charts/tempo/Chart.yaml
+++ b/charts/tempo/Chart.yaml
@@ -3,7 +3,7 @@ type: application
 name: tempo
 description: Deploy Grafana Tempo for distributed tracing with ephemeral, short-retention storage.
 icon: https://raw.githubusercontent.com/grafana/tempo/main/cmd/tempo/app/static/tempo-icon.png
-version: 0.1.0
+version: 0.1.1
 appVersion: "2.2.3"
 dependencies:
   - repository: oci://ghcr.io/grafana-community/helm-charts

--- a/charts/tempo/values.yaml
+++ b/charts/tempo/values.yaml
@@ -12,6 +12,18 @@ tempo:
           path: /var/tempo/wal
     retention: 24h
 
+    # Grafana's TraceQL metrics queries (e.g. the rate() function Traces
+    # Drilldown uses) are served by the metrics-generator's local-blocks
+    # processor. Without it running, the querier's recent-data query path
+    # fails with "error finding generators: empty ring".
+    metricsGenerator:
+      enabled: true
+    overrides:
+      defaults:
+        metrics_generator:
+          processors:
+            - local-blocks
+
     # Satisfy the restricted PodSecurity standard explicitly, since the
     # chart's pod-level defaults don't set allowPrivilegeEscalation/capabilities.
     securityContext:

--- a/deploy/clusters/prd-cph02/monitoring-system/tempo.yml
+++ b/deploy/clusters/prd-cph02/monitoring-system/tempo.yml
@@ -1,2 +1,2 @@
 chart: tempo
-tag: 0.1.0
+tag: 0.1.1


### PR DESCRIPTION
## Summary
- Grafana's Traces Drilldown app runs TraceQL metrics queries (e.g. `rate()`) against Tempo, which fail with `error finding generators: empty ring` because the metrics-generator wasn't enabled
- Enables `metricsGenerator` and the `local-blocks` processor (via `overrides.defaults.metrics_generator.processors`), which backs these recent-data queries
- Bumps `charts/tempo` to `0.1.1` and the cph02 deploy tag to match, so the change actually rolls out