### PR TITLE
feat(charts): enable JSON log output for tempo

### DIFF
--- a/charts/tempo/Chart.yaml
+++ b/charts/tempo/Chart.yaml
@@ -3,7 +3,7 @@ type: application
 name: tempo
 description: Deploy Grafana Tempo for distributed tracing with ephemeral, short-retention storage.
 icon: https://raw.githubusercontent.com/grafana/tempo/main/cmd/tempo/app/static/tempo-icon.png
-version: 0.1.1
+version: 0.1.2
 appVersion: "2.2.3"
 dependencies:
   - repository: oci://ghcr.io/grafana-community/helm-charts

--- a/charts/tempo/values.yaml
+++ b/charts/tempo/values.yaml
@@ -40,7 +40,8 @@ tempo:
   tempoQuery:
     enabled: false
 
-  # Traces only need to survive for the life of the pod, same as the Jaeger
-  # setup it replaces, so skip the PVC and use the chart's default emptyDir.
+  # Back /var/tempo with a PVC so traces survive pod restarts, not just for
+  # the life of the pod.
   persistence:
-    enabled: false
+    enabled: true
+    storageClassName: ceph-block

--- a/charts/tempo/values.yaml
+++ b/charts/tempo/values.yaml
@@ -3,6 +3,8 @@ tempo:
 
   tempo:
     reportingEnabled: false
+    server:
+      log_format: json
     storage:
       trace:
         backend: local

--- a/charts/tempo/values.yaml
+++ b/charts/tempo/values.yaml
@@ -45,3 +45,6 @@ tempo:
   persistence:
     enabled: true
     storageClassName: ceph-block
+    # 24h retention on a homelab's trace volume; the Jaeger setup this
+    # replaces only needed a 256Mi badger volume for the same window.
+    size: 1Gi

--- a/deploy/clusters/prd-cph02/monitoring-system/tempo.yml
+++ b/deploy/clusters/prd-cph02/monitoring-system/tempo.yml
@@ -1,2 +1,2 @@
 chart: tempo
-tag: 0.1.1
+tag: 0.1.2


### PR DESCRIPTION
## Summary
- Sets `server.log_format: json` so Tempo's logs match the rest of the platform's structured logging instead of the default logfmt
- Bumps `charts/tempo` to `0.1.2` and the cph02 deploy tag to match, so the change rolls out