### PR TITLE
fix(config): remove stale Jaeger datasource from grafana on cph02

### DIFF
--- a/deploy/services/grafana/20-cluster-prd-cph02.yml
+++ b/deploy/services/grafana/20-cluster-prd-cph02.yml
@@ -2,6 +2,14 @@ grafana:
   replicas: 2
   podDisruptionBudget:
     maxUnavailable: "50%"
+  # Jaeger was retired in favor of Tempo (#321), but Grafana keeps the old
+  # datasource around as provisioned, which blocks deleting it via the UI.
+  datasources:
+    datasources.yaml:
+      deleteDatasources:
+        - name: Jaeger
+          orgId: 1
+
   route:
     main:
       enabled: true


### PR DESCRIPTION
## Summary
- Jaeger was retired in favor of Tempo (#321), but Grafana still treats the old datasource as provisioned, which blocks deleting it via the UI
- Adds a `deleteDatasources` entry to the cph02 grafana override so the provisioner removes it on next sync