### PR TITLE
feat(charts): add Mimir to the monitoring-server chart

### DIFF
--- a/charts/monitoring-server/Chart.yaml
+++ b/charts/monitoring-server/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
 type: application
 name: monitoring-server
-description: A monolithic Loki log store fronted by an Alloy OTEL gateway.
+description: A monolithic Loki log store, a Mimir metrics store, and an Alloy OTEL gateway.
 icon: https://grafana.com/static/assets/img/blog/loki_logo.png
-version: 0.1.1
+version: 0.2.0
 appVersion: "3.6.7"
 dependencies:
   - repository: https://grafana.github.io/helm-charts
@@ -14,6 +14,16 @@ dependencies:
       - observability
       - loki
       - logs
+  - repository: https://grafana.github.io/helm-charts
+    name: mimir-distributed
+    # Aliased so the chart is configured under the shorter "mimir" key.
+    alias: mimir
+    version: 6.0.6
+    condition: mimir.enabled
+    tags:
+      - observability
+      - mimir
+      - metrics
   - repository: https://grafana.github.io/helm-charts
     name: alloy
     # Aliased so the OTEL gateway is configured under the "otel-gateway" key.

--- a/charts/monitoring-server/templates/mimir/_helpers.tpl
+++ b/charts/monitoring-server/templates/mimir/_helpers.tpl
@@ -1,0 +1,7 @@
+{{/* Name of the Ceph object bucket backing Mimir's block storage. Must match
+     mimir.global.extraEnvFrom's configMapRef/secretRef names in values.yaml,
+     which can't reference this helper since they're consumed verbatim by the
+     mimir subchart (not passed through tpl). */}}
+{{- define "monitoring-server.metricsBucket" -}}
+{{- printf "%s-metrics" .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}

--- a/charts/monitoring-server/templates/mimir/objectbucketclaim.yaml
+++ b/charts/monitoring-server/templates/mimir/objectbucketclaim.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.cephBuckets.metrics.enabled }}
+# Ceph object bucket backing Mimir's block storage. Generates a ConfigMap
+# (BUCKET_HOST/PORT/NAME/REGION) and a Secret (AWS_ACCESS_KEY_ID/SECRET) named
+# after this claim, consumed via mimir.global.extraEnvFrom.
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: {{ include "monitoring-server.metricsBucket" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  generateBucketName: {{ include "monitoring-server.metricsBucket" . }}
+  storageClassName: {{ .Values.cephBuckets.metrics.storageClassName }}
+{{- end }}

--- a/charts/monitoring-server/values.yaml
+++ b/charts/monitoring-server/values.yaml
@@ -38,7 +38,8 @@ otel-gateway:
         }
 
         // OTLP gateway: accept telemetry over gRPC (4317) and HTTP (4318) and
-        // forward logs to the in-cluster Loki store via its native OTLP endpoint.
+        // forward logs to Loki and metrics to Mimir via their native OTLP
+        // endpoints.
         otelcol.receiver.otlp "gateway" {
           grpc {
             endpoint = "0.0.0.0:4317"
@@ -47,20 +48,28 @@ otel-gateway:
             endpoint = "0.0.0.0:4318"
           }
           output {
-            // Only logs have a backend (Loki); metrics and traces are dropped.
-            logs = [otelcol.processor.batch.gateway.input]
+            // Traces are dropped: no backend is wired up yet.
+            logs    = [otelcol.processor.batch.gateway.input]
+            metrics = [otelcol.processor.batch.gateway.input]
           }
         }
 
         otelcol.processor.batch "gateway" {
           output {
-            logs = [otelcol.exporter.otlphttp.loki.input]
+            logs    = [otelcol.exporter.otlphttp.loki.input]
+            metrics = [otelcol.exporter.otlphttp.mimir.input]
           }
         }
 
         otelcol.exporter.otlphttp "loki" {
           client {
             endpoint = "http://monitoring-server-loki:3100/otlp"
+          }
+        }
+
+        otelcol.exporter.otlphttp "mimir" {
+          client {
+            endpoint = "http://monitoring-server-mimir-distributor:8080/otlp"
           }
         }
 
@@ -195,11 +204,149 @@ loki:
   test:
     enabled: false
 
-# Ceph object buckets provisioned by this chart (see templates/objectbucketclaim.yaml).
+# Values for the upstream grafana/mimir-distributed subchart (aliased "mimir").
+# See https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/values.yaml
+mimir:
+  enabled: true
+
+  mimir:
+    structuredConfig:
+      # Classic architecture: the distributor pushes samples straight to the
+      # ingesters over gRPC instead of through a Kafka-backed write-ahead log.
+      ingest_storage:
+        enabled: false
+      ingester:
+        push_grpc_method_enabled: true
+
+      # Block storage lives in the Ceph object bucket (see objectbucketclaim.yaml).
+      # The ${...} values are populated at runtime from the bucket claim's
+      # generated ConfigMap and Secret (wired in via global.extraEnvFrom).
+      # "common.storage" seeds blocks_storage (and alertmanager/ruler storage,
+      # both disabled below) with the same S3 backend.
+      common:
+        storage:
+          backend: s3
+          s3:
+            bucket_name: ${BUCKET_NAME}
+            endpoint: ${BUCKET_HOST}:${BUCKET_PORT}
+            region: ${BUCKET_REGION}
+            access_key_id: ${AWS_ACCESS_KEY_ID}
+            secret_access_key: ${AWS_SECRET_ACCESS_KEY}
+            # RGW is reached over plain HTTP inside the cluster and needs
+            # path-style bucket addressing, same as Loki's S3 client.
+            insecure: true
+            bucket_lookup_type: path
+
+  global:
+    extraEnvFrom:
+      # Object bucket claim outputs: BUCKET_HOST/PORT/NAME/REGION (ConfigMap).
+      # Rendered verbatim (not through tpl) by the mimir subchart, so it can't
+      # use the "monitoring-server.metricsBucket" helper: if this chart is
+      # ever installed under a release name other than "monitoring-server",
+      # update "name" below to "<release_name>-metrics" to match.
+      - configMapRef:
+          name: monitoring-server-metrics
+      # Object bucket claim outputs: AWS_ACCESS_KEY_ID/SECRET (Secret). Same
+      # "<release_name>-metrics" caveat as the configMapRef above.
+      - secretRef:
+          name: monitoring-server-metrics
+
+  # No Kafka-backed ingest storage; avoid the extra Kafka deployment.
+  kafka:
+    enabled: false
+
+  # No demo object storage; blocks live in the Ceph bucket instead.
+  minio:
+    enabled: false
+
+  # Out of scope for now: no alerting or recording/alerting rules.
+  alertmanager:
+    enabled: false
+  ruler:
+    enabled: false
+
+  # No public query path yet; skip the bundled nginx gateway.
+  gateway:
+    enabled: false
+
+  # Skip the per-tenant limits exporter; not needed for a single tenant.
+  overrides_exporter:
+    enabled: false
+
+  ingester:
+    persistentVolume:
+      storageClass: ceph-block
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "512Mi"
+      limits:
+        memory: "512Mi"
+
+  distributor:
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "512Mi"
+      limits:
+        memory: "512Mi"
+
+  querier:
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "128Mi"
+      limits:
+        memory: "128Mi"
+
+  query_frontend:
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "128Mi"
+      limits:
+        memory: "128Mi"
+
+  query_scheduler:
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "128Mi"
+      limits:
+        memory: "128Mi"
+
+  store_gateway:
+    persistentVolume:
+      storageClass: ceph-block
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "512Mi"
+      limits:
+        memory: "512Mi"
+
+  compactor:
+    persistentVolume:
+      storageClass: ceph-block
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "512Mi"
+      limits:
+        memory: "512Mi"
+
+# Ceph object buckets provisioned by this chart (see templates/*/objectbucketclaim.yaml).
 cephBuckets:
   # Backs Loki's long-term log storage. Named "<release_name>-logs" via the
   # "monitoring-server.logsBucket" helper. Disabled by default; enable per
   # cluster once the bucket should actually be provisioned (see deploy/services).
   logs:
+    enabled: false
+    storageClassName: ceph-bucket
+
+  # Backs Mimir's block storage. Named "<release_name>-metrics" via the
+  # "monitoring-server.metricsBucket" helper. Disabled by default; enable per
+  # cluster once the bucket should actually be provisioned (see deploy/services).
+  metrics:
     enabled: false
     storageClassName: ceph-bucket

--- a/charts/monitoring-server/values.yaml
+++ b/charts/monitoring-server/values.yaml
@@ -13,6 +13,14 @@ otel-gateway:
     type: deployment
     replicas: 2
 
+  # The default args omit --log-format, so the sidecar logs logfmt regardless
+  # of the "logging" block below (that only controls Alloy's own logger).
+  configReloader:
+    customArgs:
+      - --watched-dir=/etc/alloy
+      - --reload-url=http://localhost:12345/-/reload
+      - --log-format=json
+
   alloy:
     # Expose the OTLP receiver ports (the chart only opens 12345 by default).
     extraPorts:
@@ -211,6 +219,9 @@ mimir:
 
   mimir:
     structuredConfig:
+      server:
+        log_format: json
+
       # Classic architecture: the distributor pushes samples straight to the
       # ingesters over gRPC instead of through a Kafka-backed write-ahead log.
       ingest_storage:
@@ -273,23 +284,36 @@ mimir:
   overrides_exporter:
     enabled: false
 
+  # Required to coordinate the ingester/store-gateway zone-aware rollout.
+  # Override the subchart's own default memory limit (200Mi) so it matches
+  # the request, per this repo's resource policy.
+  rollout_operator:
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "100Mi"
+      limits:
+        memory: "100Mi"
+
   ingester:
     persistentVolume:
       storageClass: ceph-block
     resources:
       requests:
         cpu: "100m"
-        memory: "512Mi"
+        memory: "256Mi"
       limits:
-        memory: "512Mi"
+        memory: "256Mi"
 
   distributor:
+    # Two replicas so the write path survives a single pod restart.
+    replicas: 2
     resources:
       requests:
         cpu: "100m"
-        memory: "512Mi"
+        memory: "256Mi"
       limits:
-        memory: "512Mi"
+        memory: "256Mi"
 
   querier:
     resources:
@@ -300,6 +324,8 @@ mimir:
         memory: "128Mi"
 
   query_frontend:
+    # Two replicas so the read path survives a single pod restart.
+    replicas: 2
     resources:
       requests:
         cpu: "100m"
@@ -321,9 +347,9 @@ mimir:
     resources:
       requests:
         cpu: "100m"
-        memory: "512Mi"
+        memory: "256Mi"
       limits:
-        memory: "512Mi"
+        memory: "256Mi"
 
   compactor:
     persistentVolume:
@@ -331,9 +357,9 @@ mimir:
     resources:
       requests:
         cpu: "100m"
-        memory: "512Mi"
+        memory: "256Mi"
       limits:
-        memory: "512Mi"
+        memory: "256Mi"
 
 # Ceph object buckets provisioned by this chart (see templates/*/objectbucketclaim.yaml).
 cephBuckets:

--- a/deploy/clusters/prd-cph02/monitoring-system/monitoring-server.yml
+++ b/deploy/clusters/prd-cph02/monitoring-system/monitoring-server.yml
@@ -1,2 +1,2 @@
 chart: monitoring-server
-tag: 0.1.1
+tag: 0.2.0

--- a/deploy/services/monitoring-server/20-cluster-prd-cph02.yml
+++ b/deploy/services/monitoring-server/20-cluster-prd-cph02.yml
@@ -4,7 +4,10 @@ auth:
   clusters:
     cph02: true
 
-# Provision the Ceph object bucket backing Loki's log storage on this cluster.
+# Provision the Ceph object buckets backing Loki's log storage and Mimir's
+# block storage on this cluster.
 cephBuckets:
   logs:
+    enabled: true
+  metrics:
     enabled: true


### PR DESCRIPTION
## Summary
- Add `mimir-distributed` (aliased `mimir`) as a dependency of the monitoring-server chart, backed by its own Ceph `ObjectBucketClaim` for block storage.
- Disable the Kafka-backed ingest storage architecture so the distributor pushes straight to the ingesters over gRPC, and skip Kafka/minio/alertmanager/ruler/the nginx gateway/the overrides-exporter to keep the deployment lean.
- Wire the Alloy OTEL gateway to forward metrics to Mimir's native OTLP endpoint, alongside the existing logs-to-Loki path.
- Provision the metrics bucket on cph02 and bump the chart/deploy tag to 0.2.0.

Closes #333