### PR TITLE
feat(charts): wire Mimir into Grafana as a datasource

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -3,7 +3,7 @@ type: application
 name: grafana
 description: Deploy Grafana.
 icon: https://artifacthub.io/image/e54f5816-af00-4cc1-998e-b03de8ba5acd
-version: 0.2.2
+version: 0.2.3
 appVersion: "12.3.1"
 dependencies:
   - repository: https://grafana.github.io/helm-charts

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -1,8 +1,9 @@
 grafana:
   enabled: true
 
-  # Automatically provision the Loki log store (deployed by the
-  # monitoring-server release in the monitoring-system namespace) as a datasource.
+  # Automatically provision the Loki log store and Mimir metrics store (both
+  # deployed by the monitoring-server release in the monitoring-system
+  # namespace) as datasources.
   datasources:
     datasources.yaml:
       apiVersion: 1
@@ -17,4 +18,13 @@ grafana:
           type: loki
           access: proxy
           url: http://monitoring-server-loki.monitoring-system:3100
+          isDefault: false
+        - name: Mimir
+          uid: mimir
+          type: prometheus
+          access: proxy
+          # Query-frontend is Mimir's read-path entry point; it serves the
+          # Prometheus-compatible API itself under "/prometheus", same as it
+          # would behind the (disabled) nginx gateway.
+          url: http://monitoring-server-mimir-query-frontend.monitoring-system:8080/prometheus
           isDefault: false

--- a/deploy/clusters/prd-cph02/platform/grafana.yml
+++ b/deploy/clusters/prd-cph02/platform/grafana.yml
@@ -1,2 +1,2 @@
 chart: grafana
-tag: 0.2.2
+tag: 0.2.3


### PR DESCRIPTION
## Summary
- Provision Mimir's query-frontend (the read-path entry point) as a Prometheus-compatible Grafana datasource, alongside the existing Loki and Tempo datasources.
- Bump the grafana chart to 0.2.3 and the cph02 deploy tag to match.