### PR TITLE
feat(charts): add multitenancy_enabled and bump monitoring-server version

### DIFF
--- a/charts/monitoring-server/Chart.yaml
+++ b/charts/monitoring-server/Chart.yaml
@@ -3,7 +3,7 @@ type: application
 name: monitoring-server
 description: A monolithic Loki log store, a Mimir metrics store, and an Alloy OTEL gateway.
 icon: https://grafana.com/static/assets/img/blog/loki_logo.png
-version: 0.2.0
+version: 0.2.1
 appVersion: "3.6.7"
 dependencies:
   - repository: https://grafana.github.io/helm-charts

--- a/charts/monitoring-server/values.yaml
+++ b/charts/monitoring-server/values.yaml
@@ -222,6 +222,11 @@ mimir:
       server:
         log_format: json
 
+      # Single tenant: Grafana's Prometheus datasource doesn't send an
+      # X-Scope-OrgID header, and Mimir requires one unless multitenancy is
+      # disabled here, same as auth_enabled: false does for Loki above.
+      multitenancy_enabled: false
+
       # Classic architecture: the distributor pushes samples straight to the
       # ingesters over gRPC instead of through a Kafka-backed write-ahead log.
       ingest_storage:

--- a/deploy/clusters/prd-cph02/monitoring-system/monitoring-server.yml
+++ b/deploy/clusters/prd-cph02/monitoring-system/monitoring-server.yml
@@ -1,2 +1,2 @@
 chart: monitoring-server
-tag: 0.2.0
+tag: 0.2.1


### PR DESCRIPTION
Enables multitenancy configuration for Mimir in monitoring-server chart and updates deployment in prd-cph02.

💘 Generated with Crush