### PR TITLE
feat(charts): add monitoring-client chart and enable metrics autodiscovery in service chart

### DIFF
--- a/charts/monitoring-client/Chart.yaml
+++ b/charts/monitoring-client/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+type: application
+name: monitoring-client
+description: Ship cluster logs and metrics to the public OTEL gateway via Grafana's k8s-monitoring chart.
+icon: https://grafana.com/static/assets/img/blog/grafana_icon.png
+version: 0.1.0
+appVersion: "4.1.6"
+dependencies:
+  - repository: https://grafana.github.io/helm-charts
+    name: k8s-monitoring
+    version: 4.1.6
+    condition: k8s-monitoring.enabled
+    tags:
+      - observability
+      - k8s-monitoring
+      - otel

--- a/charts/monitoring-client/artifacthub-repo.yml
+++ b/charts/monitoring-client/artifacthub-repo.yml
@@ -1,0 +1,7 @@
+# References:
+# - https://artifacthub.io/docs/topics/repositories/container-images/#repository-metadata
+# - https://github.com/artifacthub/hub/blob/master/docs/metadata/artifacthub-repo.yml
+repositoryID: ""
+owners:
+  - name: Nicklas Frahm
+    email: nicklas.frahm@gmail.com

--- a/charts/monitoring-client/values.yaml
+++ b/charts/monitoring-client/values.yaml
@@ -1,0 +1,137 @@
+# Values for the upstream grafana/k8s-monitoring subchart.
+# See https://github.com/grafana/k8s-monitoring-helm/blob/main/charts/k8s-monitoring/values.yaml
+#
+# Cluster identity (cluster.name) and the OTLP destination's url/extraHeaders
+# are cluster-specific and are set per cluster in deploy/services overlays,
+# not here.
+k8s-monitoring:
+  enabled: true
+
+  cluster:
+    # Required by the upstream chart's own validation. Overridden with the
+    # real cluster name per cluster in deploy/services overlays.
+    name: "unconfigured"
+
+  # Ship telemetry to monitoring-server's public OTEL gateway (see the
+  # monitoring-server chart's otel-gateway). Authenticates with this pod's own
+  # projected ServiceAccount token: the gateway validates it against this
+  # cluster's own OIDC issuer JWKS, so no extra credentials are needed.
+  destinations:
+    monitoring-server:
+      type: otlp
+      protocol: http
+      url: ""
+      metrics:
+        enabled: true
+      logs:
+        enabled: true
+      traces:
+        enabled: false
+      auth:
+        type: bearerToken
+        bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      extraHeaders:
+        X-Cluster: ""
+
+  clusterMetrics:
+    enabled: true
+    collector: alloy-metrics
+    kube-state-metrics:
+      # kube-state-metrics runs 2 replicas behind a Service for HA (see
+      # telemetryServices.kube-state-metrics.replicas below); scrape the
+      # Service so only one replica is sampled per cycle instead of both
+      # (which would double-count every metric).
+      discoveryType: service
+
+  hostMetrics:
+    enabled: true
+    collector: alloy-metrics
+
+  clusterEvents:
+    enabled: true
+    collector: alloy-singleton
+
+  podLogsViaOpenTelemetry:
+    enabled: true
+    collector: alloy-logs
+
+  # Scrapes any pod/service across all namespaces carrying the
+  # k8s.grafana.com/scrape annotation (see the service chart's `metrics`
+  # block for the producer side). namespaces is left empty so every
+  # namespace is included.
+  annotationAutodiscovery:
+    enabled: true
+    collector: alloy-metrics
+
+  # The Alloy Operator manages the Alloy custom resources below.
+  alloy-operator:
+    resources:
+      requests:
+        cpu: "50m"
+        memory: "64Mi"
+      limits:
+        memory: "64Mi"
+
+  # kube-state-metrics and node-exporter aren't deployed elsewhere in this
+  # cluster yet, so let this chart deploy them.
+  telemetryServices:
+    kube-state-metrics:
+      # 2 replicas behind a Service for HA. kube-state-metrics is stateless
+      # (each replica computes the same full snapshot), so this needs no
+      # autosharding: only one replica answers a given scrape.
+      replicas: 2
+      resources:
+        requests:
+          cpu: "50m"
+          memory: "128Mi"
+        limits:
+          memory: "128Mi"
+      deploy: true
+    node-exporter:
+      resources:
+        requests:
+          cpu: "50m"
+          memory: "64Mi"
+        limits:
+          memory: "64Mi"
+      deploy: true
+
+  # Each Alloy collector instance. See
+  # https://github.com/grafana/k8s-monitoring-helm/blob/main/charts/k8s-monitoring/docs/collectors/README.md
+  collectors:
+    # Scrapes cluster and host metrics; clustering distributes scrape targets
+    # across replicas.
+    alloy-metrics:
+      presets: [clustered, statefulset]
+      alloy:
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "256Mi"
+          limits:
+            memory: "256Mi"
+
+    # Reads pod logs from each node's filesystem.
+    alloy-logs:
+      presets: [daemonset, filesystem-log-reader]
+      alloy:
+        # Required by the (public-preview) Pod Logs via OpenTelemetry feature.
+        stabilityLevel: public-preview
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            memory: "128Mi"
+
+    # Watches Kubernetes events; must run as a single instance to avoid
+    # duplicate events.
+    alloy-singleton:
+      presets: [singleton, deployment]
+      alloy:
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            memory: "128Mi"

--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -3,4 +3,4 @@ type: application
 name: service
 description: A Helm chart for deploying a generic service in a Kubernetes cluster.
 icon: https://cdn-icons-png.flaticon.com/512/9402/9402265.png
-version: 0.2.4
+version: 0.3.0

--- a/charts/service/templates/deployment.yml
+++ b/charts/service/templates/deployment.yml
@@ -13,6 +13,18 @@ spec:
   template:
     metadata:
       labels: {{- include "service.labels" . | nindent 8 }}
+      {{- if .Values.metrics.enabled }}
+      annotations:
+        k8s.grafana.com/scrape: "true"
+        k8s.grafana.com/metrics.portNumber: {{ .Values.metrics.port | default .Values.service.containerPort | quote }}
+        k8s.grafana.com/metrics.path: {{ .Values.metrics.path | quote }}
+        {{- if .Values.metrics.scrapeInterval }}
+        k8s.grafana.com/metrics.scrapeInterval: {{ .Values.metrics.scrapeInterval | quote }}
+        {{- end }}
+        {{- if .Values.metrics.scrapeTimeout }}
+        k8s.grafana.com/metrics.scrapeTimeout: {{ .Values.metrics.scrapeTimeout | quote }}
+        {{- end }}
+      {{- end }}
     spec:
       containers:
         - name: {{ .Release.Name | quote }}

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -74,3 +74,15 @@ probes:
     enabled: true
     port: 8081
     path: /startup
+
+# Annotation-based metrics autodiscovery (see monitoring-client's
+# annotationAutodiscovery feature, which scrapes pods carrying these
+# k8s.grafana.com annotations).
+metrics:
+  enabled: false
+  # Defaults to service.containerPort when empty.
+  port: ""
+  path: /metrics
+  # Defaults to the autodiscovery feature's own scrape interval/timeout when empty.
+  scrapeInterval: ""
+  scrapeTimeout: ""

--- a/deploy/clusters/prd-cph02/monitoring-system/monitoring-client.yml
+++ b/deploy/clusters/prd-cph02/monitoring-system/monitoring-client.yml
@@ -1,0 +1,2 @@
+chart: monitoring-client
+tag: 0.1.0

--- a/deploy/clusters/prd-cph02/monitoring-system/speedtest-exporter.yml
+++ b/deploy/clusters/prd-cph02/monitoring-system/speedtest-exporter.yml
@@ -1,2 +1,2 @@
 chart: service
-tag: 0.2.4
+tag: 0.3.0

--- a/deploy/services/monitoring-client/00-base.yml
+++ b/deploy/services/monitoring-client/00-base.yml
@@ -1,0 +1,2 @@
+# Base values for the monitoring-client release. Cluster identity and the
+# OTEL gateway destination are configured per cluster in 20-cluster-<cluster>.yml.

--- a/deploy/services/monitoring-client/20-cluster-prd-cph02.yml
+++ b/deploy/services/monitoring-client/20-cluster-prd-cph02.yml
@@ -1,0 +1,12 @@
+# Ship this cluster's logs and metrics to monitoring-server's public OTEL
+# gateway, identifying as "cph02" (see monitoring-server's
+# auth.clusters.cph02 admission and its otel.nicklasfrahm.dev route).
+k8s-monitoring:
+  cluster:
+    name: cph02
+
+  destinations:
+    monitoring-server:
+      url: https://otel.nicklasfrahm.dev
+      extraHeaders:
+        X-Cluster: cph02

--- a/deploy/services/speedtest-exporter/00-base.yml
+++ b/deploy/services/speedtest-exporter/00-base.yml
@@ -29,3 +29,10 @@ probes:
 autoscaling:
   enabled: false
   minReplicas: 1
+
+# Each scrape runs an actual speedtest, so use a long interval/timeout
+# (upstream's own recommendation: https://github.com/danopstech/speedtest_exporter).
+metrics:
+  enabled: true
+  scrapeInterval: 60m
+  scrapeTimeout: 60s


### PR DESCRIPTION
Introduces a new `monitoring-client` Helm chart based on Grafana's `k8s-monitoring` to collect cluster logs and metrics via OpenTelemetry. This includes configuration for Alloy collectors (metrics, logs, and events).

Updates the `service` chart to support annotation-based metrics autodiscovery using `k8s.grafana.com` annotations.

Configures deployment for `monitoring-client` and `speedtest-exporter` in the `prd-cph02` cluster.