### PR TITLE
fix(config): raise monitoring-system to privileged PodSecurity

### DIFF
--- a/deploy/services/argocd-apps/20-cluster-prd-cph02.yml
+++ b/deploy/services/argocd-apps/20-cluster-prd-cph02.yml
@@ -5,3 +5,11 @@ tenants:
     enabled: true
   monitoring-system:
     enabled: true
+    # node-exporter and Alloy's log collector need hostPath/hostNetwork/
+    # hostPID/hostPort, which Kubernetes' "baseline" Pod Security Standard
+    # (the cluster's default, set in the Talos control plane config)
+    # disallows outright. There's no narrower exemption for just those
+    # controls, so this namespace needs "privileged".
+    namespace:
+      labels:
+        pod-security.kubernetes.io/enforce: privileged


### PR DESCRIPTION
## Summary
- node-exporter and Alloy's log collector (`monitoring-client`) need hostPath, hostNetwork, hostPID, and hostPort, which the cluster's default "baseline" PodSecurity enforcement disallows with no narrower exemption.
- Raises the `monitoring-system` namespace to `pod-security.kubernetes.io/enforce: privileged`, mirroring the existing `platform` tenant's pattern.