### PR TITLE
fix(charts): correct OTEL gateway JWKS path and alloy-operator memory

### DIFF
--- a/charts/monitoring-client/Chart.yaml
+++ b/charts/monitoring-client/Chart.yaml
@@ -3,7 +3,7 @@ type: application
 name: monitoring-client
 description: Ship cluster logs and metrics to the public OTEL gateway via Grafana's k8s-monitoring chart.
 icon: https://grafana.com/static/assets/img/blog/grafana_icon.png
-version: 0.1.0
+version: 0.1.1
 appVersion: "4.1.6"
 dependencies:
   - repository: https://grafana.github.io/helm-charts

--- a/charts/monitoring-client/values.yaml
+++ b/charts/monitoring-client/values.yaml
@@ -71,9 +71,9 @@ k8s-monitoring:
     resources:
       requests:
         cpu: "50m"
-        memory: "192Mi"
+        memory: "128Mi"
       limits:
-        memory: "192Mi"
+        memory: "128Mi"
 
   # kube-state-metrics and node-exporter aren't deployed elsewhere in this
   # cluster yet, so let this chart deploy them.

--- a/charts/monitoring-client/values.yaml
+++ b/charts/monitoring-client/values.yaml
@@ -63,14 +63,17 @@ k8s-monitoring:
     enabled: true
     collector: alloy-metrics
 
-  # The Alloy Operator manages the Alloy custom resources below.
+  # The Alloy Operator manages the Alloy custom resources below. It watches
+  # every namespace plus several resource kinds cluster-wide, which needs
+  # more headroom than a typical sidecar controller: 64Mi was OOMKilling it
+  # repeatedly, which also left the alloy-metrics StatefulSet half-reconciled.
   alloy-operator:
     resources:
       requests:
         cpu: "50m"
-        memory: "64Mi"
+        memory: "192Mi"
       limits:
-        memory: "64Mi"
+        memory: "192Mi"
 
   # kube-state-metrics and node-exporter aren't deployed elsewhere in this
   # cluster yet, so let this chart deploy them.

--- a/charts/monitoring-server/Chart.yaml
+++ b/charts/monitoring-server/Chart.yaml
@@ -3,7 +3,7 @@ type: application
 name: monitoring-server
 description: A monolithic Loki log store, a Mimir metrics store, and an Alloy OTEL gateway.
 icon: https://grafana.com/static/assets/img/blog/loki_logo.png
-version: 0.2.1
+version: 0.2.2
 appVersion: "3.6.7"
 dependencies:
   - repository: https://grafana.github.io/helm-charts

--- a/charts/monitoring-server/values.yaml
+++ b/charts/monitoring-server/values.yaml
@@ -93,8 +93,9 @@ route:
 
 auth:
   # Path appended to https://oidc.<cluster>.<platform.domain> for the JWKS.
-  # NOTE: the llm chart uses "/openid/v1/jwks"; reconcile if they must match.
-  jwksPath: "/v1/openid/jwks"
+  # Matches the Kubernetes API server's own OIDC discovery path (also used by
+  # the llm chart's jwksUri), not "/v1/openid/jwks".
+  jwksPath: "/openid/v1/jwks"
   # Each "true" entry admits a cluster: it creates an HTTPRoute matching
   # "X-Cluster: <cluster>" plus a SecurityPolicy that accepts JWTs from
   # https://oidc.<cluster>.<platform.domain><jwksPath>.

--- a/deploy/clusters/prd-cph02/monitoring-system/monitoring-client.yml
+++ b/deploy/clusters/prd-cph02/monitoring-system/monitoring-client.yml
@@ -1,2 +1,2 @@
 chart: monitoring-client
-tag: 0.1.0
+tag: 0.1.1

--- a/deploy/clusters/prd-cph02/monitoring-system/monitoring-server.yml
+++ b/deploy/clusters/prd-cph02/monitoring-system/monitoring-server.yml
@@ -1,2 +1,2 @@
 chart: monitoring-server
-tag: 0.2.1
+tag: 0.2.2


### PR DESCRIPTION
## Summary
- `monitoring-server`'s `auth.jwksPath` defaulted to `/v1/openid/jwks`, but the Kubernetes API server's actual OIDC discovery JWKS endpoint is `/openid/v1/jwks`. The gateway's `SecurityPolicy` could never fetch the JWKS at the wrong path, so every `monitoring-client` collector got rejected with a 401.
- `alloy-operator`'s 64Mi memory limit was too tight and OOMKilling it repeatedly, which also left the `alloy-metrics` StatefulSet half-reconciled (it never got created). Bumped to 192Mi.