### PR TITLE
fix(config): bump speedtest exporter to v1.1.1 and use new health endpoints

### DIFF
--- a/deploy/services/speedtest-exporter/00-base.yml
+++ b/deploy/services/speedtest-exporter/00-base.yml
@@ -1,7 +1,7 @@
 # Image configuration - override default image
 image:
   repository: "ghcr.io/nicklasfrahm/prometheus-speedtest-exporter"
-  tag: "v1.0.1"
+  tag: "v1.1.1"
 
 # Service configuration - override default port
 service:
@@ -17,22 +17,22 @@ resources:
 probes:
   liveness:
     port: 9516
-    path: /healthz
+    path: /livez
   readiness:
     port: 9516
-    path: /healthz
+    path: /readyz
   startup:
     port: 9516
-    path: /healthz
+    path: /readyz
 
 # Disable autoscaling for Prometheus exporter
 autoscaling:
   enabled: false
   minReplicas: 1
 
-# Each scrape runs an actual speedtest, so use a long interval/timeout
+# /metrics always serves from cache, so scrapes only need to cover the
+# HTTP round trip, not a full speedtest
 # (see https://github.com/nicklasfrahm/prometheus-speedtest-exporter).
 metrics:
   enabled: true
-  scrapeInterval: 60m
-  scrapeTimeout: 120s
+  scrapeInterval: 1m


### PR DESCRIPTION
## Summary
- Bump speedtest exporter image to v1.1.1
- Switch liveness/readiness probes to the new /livez and /readyz endpoints (startup probe also uses /readyz so it waits for a completed speedtest result)
- Drop the custom scrape timeout and set scrape interval to 1m, now that /metrics serves from cache instead of running a live speedtest per scrape