### PR TITLE
fix(charts): gate HPA on autoscaling.enabled and make probe timing configurable

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -3,4 +3,4 @@ type: application
 name: service
 description: A Helm chart for deploying a generic service in a Kubernetes cluster.
 icon: https://cdn-icons-png.flaticon.com/512/9402/9402265.png
-version: 0.3.0
+version: 0.3.1

--- a/charts/service/templates/deployment.yml
+++ b/charts/service/templates/deployment.yml
@@ -66,22 +66,26 @@ spec:
             httpGet:
               path: {{ .Values.probes.startup.path | quote }}
               port: http
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
           {{- end }}
           {{- if .Values.probes.readiness.enabled }}
           readinessProbe:
             httpGet:
               path: {{ .Values.probes.readiness.path | quote }}
               port: http
-            initialDelaySeconds: 5
-            periodSeconds: 10
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
           {{- end }}
           {{- if .Values.probes.liveness.enabled }}
           livenessProbe:
             httpGet:
               path: {{ .Values.probes.liveness.path | quote }}
               port: http
-            initialDelaySeconds: 30
-            periodSeconds: 10
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
           {{- end }}
           resources:
             requests:

--- a/charts/service/templates/hpa.yml
+++ b/charts/service/templates/hpa.yml
@@ -1,3 +1,4 @@
+{{- if .Values.autoscaling.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -28,3 +29,4 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.resource.memory.targetUtilizationPercentage }}
     {{- end }}
+{{- end }}

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -66,14 +66,22 @@ probes:
     enabled: true
     port: 8081
     path: /live
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    failureThreshold: 3
   readiness:
     enabled: true
     port: 8081
     path: /ready
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    failureThreshold: 3
   startup:
     enabled: true
     port: 8081
     path: /startup
+    periodSeconds: 10
+    failureThreshold: 3
 
 # Annotation-based metrics autodiscovery (see monitoring-client's
 # annotationAutodiscovery feature, which scrapes pods carrying these

--- a/deploy/clusters/prd-cph02/monitoring-system/speedtest-exporter.yml
+++ b/deploy/clusters/prd-cph02/monitoring-system/speedtest-exporter.yml
@@ -1,2 +1,2 @@
 chart: service
-tag: 0.3.0
+tag: 0.3.1

--- a/deploy/services/speedtest-exporter/00-base.yml
+++ b/deploy/services/speedtest-exporter/00-base.yml
@@ -24,6 +24,9 @@ probes:
   startup:
     port: 9516
     path: /readyz
+    # Allow up to 5m for the container to become ready.
+    periodSeconds: 10
+    failureThreshold: 30
 
 # Disable autoscaling for Prometheus exporter
 autoscaling:


### PR DESCRIPTION
## Summary
- `charts/service` rendered an HPA unconditionally, ignoring `autoscaling.enabled` — gate `hpa.yml` on the flag so disabling autoscaling actually removes the HPA
- Expose `periodSeconds`/`failureThreshold` (and `initialDelaySeconds` where missing) on all three probes so consumers can tune timing via values instead of patching the chart; defaults are unchanged
- Bump chart version to 0.3.1 and the speedtest-exporter app's pinned tag to match
- speedtest-exporter: its `autoscaling.enabled: false` now actually disables the HPA, and its startup probe is relaxed to allow up to 5m (periodSeconds 10 x failureThreshold 30) before failing