### PR TITLE
fix(charts): explicitly enable log level detection as structured metadata in Loki

### DIFF
--- a/charts/monitoring-server/Chart.yaml
+++ b/charts/monitoring-server/Chart.yaml
@@ -3,7 +3,7 @@ type: application
 name: monitoring-server
 description: A monolithic Loki log store, a Mimir metrics store, and an Alloy OTEL gateway.
 icon: https://grafana.com/static/assets/img/blog/loki_logo.png
-version: 0.2.2
+version: 0.2.3
 appVersion: "3.6.7"
 dependencies:
   - repository: https://grafana.github.io/helm-charts

--- a/charts/monitoring-server/values.yaml
+++ b/charts/monitoring-server/values.yaml
@@ -154,6 +154,13 @@ loki:
       retention_period: 168h # 7 days
       reject_old_samples: true
       reject_old_samples_max_age: 168h
+      # Pin these explicitly rather than relying on Loki's own defaults:
+      # auto-detect "level" (or Level/Severity/lvl, case-insensitive values)
+      # from JSON log lines and attach it as structured metadata, so it's
+      # filterable per line without becoming an indexed label/stream
+      # (indexing level would multiply streams per service).
+      discover_log_levels: true
+      allow_structured_metadata: true
 
     # Enable the compactor to actually delete chunks past the retention period.
     structuredConfig:

--- a/deploy/clusters/prd-cph02/monitoring-system/monitoring-server.yml
+++ b/deploy/clusters/prd-cph02/monitoring-system/monitoring-server.yml
@@ -1,2 +1,2 @@
 chart: monitoring-server
-tag: 0.2.2
+tag: 0.2.3


### PR DESCRIPTION
## Summary
- Investigated making `level` queryable in Loki. Two options exist: index it as a real label/stream (rejected — multiplies streams per service, against Loki's own cardinality guidance and a known bug where log-level attributes can't reliably become index labels via `otlp_config` anyway), or let Loki auto-detect it into structured metadata (chosen).
- Loki 3.6.7 already defaults `discover_log_levels` and `allow_structured_metadata` to `true`, which auto-detects a `level`/`Level`/`Severity`/`lvl` field from JSON log lines and attaches it as structured metadata — filterable per line (`| level="error"`) without creating a new stream per level.
- Pin both explicitly in `charts/monitoring-server` values so this is documented intent rather than an implicit Loki default that could silently change on a future Loki bump.
- Bump chart to 0.2.3 and the pinned app tag to match.