### PR TITLE
fix(config): bump speedtest exporter to v1.1.2

### DIFF
--- a/deploy/services/speedtest-exporter/00-base.yml
+++ b/deploy/services/speedtest-exporter/00-base.yml
@@ -1,7 +1,7 @@
 # Image configuration - override default image
 image:
   repository: "ghcr.io/nicklasfrahm/prometheus-speedtest-exporter"
-  tag: "v1.1.1"
+  tag: "v1.1.2"
 
 # Service configuration - override default port
 service:


### PR DESCRIPTION
## Summary
- Bump the speedtest-exporter image tag in the base config from v1.1.1 to v1.1.2