### PR TITLE
feat(charts): support nested chart.name/chart.tag overrides in argocd-apps

### DIFF
--- a/charts/argocd-apps/Chart.yaml
+++ b/charts/argocd-apps/Chart.yaml
@@ -3,5 +3,5 @@ type: application
 name: argocd-apps
 description: Configure ArgoCD ApplicationSets for multi-tenant clusters.
 icon: https://artifacthub.io/image/e16221f4-a3b1-49f6-9b65-cb4dbf30ed83
-version: 3.0.0
-appVersion: "3.0.0"
+version: 3.1.0
+appVersion: "3.1.0"

--- a/charts/argocd-apps/templates/applicationset.yaml
+++ b/charts/argocd-apps/templates/applicationset.yaml
@@ -34,8 +34,8 @@ spec:
         namespace: '{{ $tenantName }}'
       sources:
         - repoURL: {{ $.Values.chart.repository | quote }}
-          chart: '{{`{{ .chart }}`}}'
-          targetRevision: '{{`{{ .tag }}`}}'
+          chart: '{{`{{ if kindIs "map" .chart }}{{ .chart.name }}{{ else }}{{ .chart }}{{ end }}`}}'
+          targetRevision: '{{`{{ if kindIs "map" .chart }}{{ .chart.tag }}{{ else }}{{ .tag }}{{ end }}`}}'
           helm:
             releaseName: '{{`{{ .values.release }}`}}'
             ignoreMissingValueFiles: true

--- a/deploy/clusters/prd-cph02/argocd/argocd-apps.yml
+++ b/deploy/clusters/prd-cph02/argocd/argocd-apps.yml
@@ -1,2 +1,2 @@
 chart: argocd-apps
-tag: 3.0.0
+tag: 3.1.0

--- a/deploy/clusters/prd-cph02/monitoring-system/speedtest-exporter.yml
+++ b/deploy/clusters/prd-cph02/monitoring-system/speedtest-exporter.yml
@@ -1,2 +1,3 @@
-chart: service
-tag: 0.3.1
+chart:
+  name: service
+  tag: 0.3.1


### PR DESCRIPTION
## Summary
- `argocd-apps` ApplicationSet template now accepts a nested `chart: {name:, tag:}` structure in per-release deploy files, in addition to the existing flat `chart:`/`tag:` keys, enabling instance-level overrides
- Bumps the `argocd-apps` chart to 3.1.0 and updates its own deploy tag in `prd-cph02` to match

Closes #323 (part 1 of 2 — rollout of the new structure across `cph02` deployments is a follow-up PR).