### PR TITLE
fix(config): use nested chart.name/chart.tag structure in monitoring-system

### DIFF
--- a/deploy/clusters/prd-cph02/monitoring-system/monitoring-client.yml
+++ b/deploy/clusters/prd-cph02/monitoring-system/monitoring-client.yml
@@ -1,2 +1,3 @@
-chart: monitoring-client
-tag: 0.1.1
+chart:
+  name: monitoring-client
+  tag: 0.1.1

--- a/deploy/clusters/prd-cph02/monitoring-system/monitoring-server.yml
+++ b/deploy/clusters/prd-cph02/monitoring-system/monitoring-server.yml
@@ -1,2 +1,3 @@
-chart: monitoring-server
-tag: 0.2.3
+chart:
+  name: monitoring-server
+  tag: 0.2.3

--- a/deploy/clusters/prd-cph02/monitoring-system/tempo.yml
+++ b/deploy/clusters/prd-cph02/monitoring-system/tempo.yml
@@ -1,2 +1,3 @@
-chart: tempo
-tag: 0.1.2
+chart:
+  name: tempo
+  tag: 0.1.2


### PR DESCRIPTION
## Summary
- Converts the remaining `monitoring-system` releases in `cph02` (`monitoring-client`, `monitoring-server`, `tempo`) to the nested `chart: {name, tag}` structure introduced in #354
- `speedtest-exporter` was already converted as part of #354

Part of the rollout described in #323 (currently scoped to the `monitoring-system` namespace).