### PR TITLE
fix(config): use nested chart.name/chart.tag structure across cph02

### DIFF
--- a/deploy/clusters/prd-cph02/argocd/argocd-apps.yml
+++ b/deploy/clusters/prd-cph02/argocd/argocd-apps.yml
@@ -1,2 +1,3 @@
-chart: argocd-apps
-tag: 3.1.0
+chart:
+  name: argocd-apps
+  tag: 3.1.0

--- a/deploy/clusters/prd-cph02/argocd/argocd.yml
+++ b/deploy/clusters/prd-cph02/argocd/argocd.yml
@@ -1,2 +1,3 @@
-chart: argocd
-tag: 1.0.5
+chart:
+  name: argocd
+  tag: 1.0.5

--- a/deploy/clusters/prd-cph02/kube-system/cilium.yml
+++ b/deploy/clusters/prd-cph02/kube-system/cilium.yml
@@ -1,2 +1,3 @@
-chart: cilium
-tag: 1.0.2
+chart:
+  name: cilium
+  tag: 1.0.2

--- a/deploy/clusters/prd-cph02/kube-system/loadbalancer.yml
+++ b/deploy/clusters/prd-cph02/kube-system/loadbalancer.yml
@@ -1,2 +1,3 @@
-chart: bgp-loadbalancing
-tag: 0.1.1
+chart:
+  name: bgp-loadbalancing
+  tag: 0.1.1

--- a/deploy/clusters/prd-cph02/platform/authz.yml
+++ b/deploy/clusters/prd-cph02/platform/authz.yml
@@ -1,2 +1,3 @@
-chart: authz
-tag: 1.0.0
+chart:
+  name: authz
+  tag: 1.0.0

--- a/deploy/clusters/prd-cph02/platform/cert-manager.yml
+++ b/deploy/clusters/prd-cph02/platform/cert-manager.yml
@@ -1,2 +1,3 @@
-chart: cert-manager
-tag: 1.0.0
+chart:
+  name: cert-manager
+  tag: 1.0.0

--- a/deploy/clusters/prd-cph02/platform/cnpg-operator.yml
+++ b/deploy/clusters/prd-cph02/platform/cnpg-operator.yml
@@ -1,2 +1,3 @@
-chart: cnpg-operator
-tag: 0.1.0
+chart:
+  name: cnpg-operator
+  tag: 0.1.0

--- a/deploy/clusters/prd-cph02/platform/dex.yml
+++ b/deploy/clusters/prd-cph02/platform/dex.yml
@@ -1,2 +1,3 @@
-chart: dex
-tag: 1.0.5
+chart:
+  name: dex
+  tag: 1.0.5

--- a/deploy/clusters/prd-cph02/platform/envoy-gateway.yml
+++ b/deploy/clusters/prd-cph02/platform/envoy-gateway.yml
@@ -1,2 +1,3 @@
-chart: envoy-gateway
-tag: 0.1.1
+chart:
+  name: envoy-gateway
+  tag: 0.1.1

--- a/deploy/clusters/prd-cph02/platform/grafana-postgres.yml
+++ b/deploy/clusters/prd-cph02/platform/grafana-postgres.yml
@@ -1,2 +1,3 @@
-chart: cnpg-cluster
-tag: 0.1.0
+chart:
+  name: cnpg-cluster
+  tag: 0.1.0

--- a/deploy/clusters/prd-cph02/platform/grafana.yml
+++ b/deploy/clusters/prd-cph02/platform/grafana.yml
@@ -1,2 +1,3 @@
-chart: grafana
-tag: 0.2.3
+chart:
+  name: grafana
+  tag: 0.2.3

--- a/deploy/clusters/prd-cph02/platform/kserve.yml
+++ b/deploy/clusters/prd-cph02/platform/kserve.yml
@@ -1,2 +1,3 @@
-chart: kserve
-tag: 1.0.2
+chart:
+  name: kserve
+  tag: 1.0.2

--- a/deploy/clusters/prd-cph02/platform/kubeconfig-server.yml
+++ b/deploy/clusters/prd-cph02/platform/kubeconfig-server.yml
@@ -1,2 +1,3 @@
-chart: kubeconfig-server
-tag: 1.0.1
+chart:
+  name: kubeconfig-server
+  tag: 1.0.1

--- a/deploy/clusters/prd-cph02/platform/metrics-server.yml
+++ b/deploy/clusters/prd-cph02/platform/metrics-server.yml
@@ -1,2 +1,3 @@
-chart: metrics-server
-tag: 1.0.0
+chart:
+  name: metrics-server
+  tag: 1.0.0

--- a/deploy/clusters/prd-cph02/platform/nvidia-device-plugin.yml
+++ b/deploy/clusters/prd-cph02/platform/nvidia-device-plugin.yml
@@ -1,2 +1,3 @@
-chart: nvidia-device-plugin
-tag: 1.0.0
+chart:
+  name: nvidia-device-plugin
+  tag: 1.0.0

--- a/deploy/clusters/prd-cph02/platform/oidc-discovery-proxy.yml
+++ b/deploy/clusters/prd-cph02/platform/oidc-discovery-proxy.yml
@@ -1,2 +1,3 @@
-chart: oidc-discovery-proxy
-tag: 1.0.3
+chart:
+  name: oidc-discovery-proxy
+  tag: 1.0.3

--- a/deploy/clusters/prd-cph02/platform/public-web-gateway.yml
+++ b/deploy/clusters/prd-cph02/platform/public-web-gateway.yml
@@ -1,2 +1,3 @@
-chart: gateway
-tag: 1.4.0
+chart:
+  name: gateway
+  tag: 1.4.0

--- a/deploy/clusters/prd-cph02/platform/rook-ceph-cluster.yml
+++ b/deploy/clusters/prd-cph02/platform/rook-ceph-cluster.yml
@@ -1,2 +1,3 @@
-chart: rook-ceph-cluster
-tag: 0.3.18
+chart:
+  name: rook-ceph-cluster
+  tag: 0.3.18

--- a/deploy/clusters/prd-cph02/platform/rook-ceph.yml
+++ b/deploy/clusters/prd-cph02/platform/rook-ceph.yml
@@ -1,2 +1,3 @@
-chart: rook-ceph
-tag: 0.2.1
+chart:
+  name: rook-ceph
+  tag: 0.2.1


### PR DESCRIPTION
## Summary
- Converts every remaining release in `prd-cph02` (`argocd`, `kube-system`, `platform` namespaces) from the flat `chart:`/`tag:` structure to the nested `chart: {name, tag}` structure introduced in #354
- `monitoring-system` was already converted in #355

Closes #323.