### PR TITLE
fix(charts): support instance-level overrides in argocd-apps

### DIFF
--- a/charts/argocd-apps/Chart.yaml
+++ b/charts/argocd-apps/Chart.yaml
@@ -3,5 +3,5 @@ type: application
 name: argocd-apps
 description: Configure ArgoCD ApplicationSets for multi-tenant clusters.
 icon: https://artifacthub.io/image/e16221f4-a3b1-49f6-9b65-cb4dbf30ed83
-version: 3.1.0
-appVersion: "3.1.0"
+version: 4.0.0
+appVersion: "4.0.0"

--- a/charts/argocd-apps/templates/applicationset.yaml
+++ b/charts/argocd-apps/templates/applicationset.yaml
@@ -44,6 +44,7 @@ spec:
               - '$values/deploy/services/{{`{{ .values.release }}`}}/10-env-{{ $environment }}.yml'
               - '$values/deploy/services/{{`{{ .values.release }}`}}/20-cluster-{{ $cluster }}.yml'
               - '$values/deploy/services/{{`{{ .values.release }}`}}/30-tenant-{{ $tenantName }}.yml'
+              - '$values/deploy/clusters/{{ $cluster }}/{{ $tenantName }}/{{`{{ .values.release }}`}}.yml'
             values: |
               platform:
                 cluster: {{ $cluster | quote }}
@@ -51,9 +52,6 @@ spec:
                 location: {{ $location | quote }}
                 tenant: {{ $tenantName | quote }}
                 domain: {{ $.Values.domain | quote }}
-              {{`{{- with omit . "path" "values" }}`}}
-              {{`{{ toYaml . }}`}}
-              {{`{{- end }}`}}
         - repoURL: {{ $.Values.config.repository | quote }}
           targetRevision: main
           ref: values

--- a/charts/argocd-apps/templates/applicationset.yaml
+++ b/charts/argocd-apps/templates/applicationset.yaml
@@ -34,8 +34,8 @@ spec:
         namespace: '{{ $tenantName }}'
       sources:
         - repoURL: {{ $.Values.chart.repository | quote }}
-          chart: '{{`{{ if kindIs "map" .chart }}{{ .chart.name }}{{ else }}{{ .chart }}{{ end }}`}}'
-          targetRevision: '{{`{{ if kindIs "map" .chart }}{{ .chart.tag }}{{ else }}{{ .tag }}{{ end }}`}}'
+          chart: '{{`{{ .chart.name }}`}}'
+          targetRevision: '{{`{{ .chart.tag }}`}}'
           helm:
             releaseName: '{{`{{ .values.release }}`}}'
             ignoreMissingValueFiles: true
@@ -51,6 +51,9 @@ spec:
                 location: {{ $location | quote }}
                 tenant: {{ $tenantName | quote }}
                 domain: {{ $.Values.domain | quote }}
+              {{`{{- with omit . "path" "values" }}`}}
+              {{`{{ toYaml . }}`}}
+              {{`{{- end }}`}}
         - repoURL: {{ $.Values.config.repository | quote }}
           targetRevision: main
           ref: values

--- a/deploy/clusters/prd-cph02/argocd/argocd-apps.yml
+++ b/deploy/clusters/prd-cph02/argocd/argocd-apps.yml
@@ -1,3 +1,3 @@
 chart:
   name: argocd-apps
-  tag: 3.1.0
+  tag: 4.0.0


### PR DESCRIPTION
## Summary
- Enables instance-level overrides (#323): each release yaml can now override any Helm value for its instance, with the highest precedence among the layered value files
- `argocd-apps` ApplicationSet now requires the nested `chart: {name, tag}` structure and drops support for the old flat `chart:`/`tag:` keys, now that every release in `cph02` has been migrated
- The release yaml itself is added as the last entry in `valueFiles`, so it wins over `00-base` < `10-env` < `20-cluster` < `30-tenant`. This also means `chart.name`/`chart.tag` are passed through as regular Helm values.
- Bumps the `argocd-apps` chart to 4.0.0 (breaking: flat structure no longer supported) and updates its own deploy tag in `prd-cph02` to match