### PR TITLE
fix(charts): rename kaether dex client to kontinuum

### DIFF
--- a/deploy/services/dex/00-base.yml
+++ b/deploy/services/dex/00-base.yml
@@ -40,8 +40,8 @@ dex:
         allowOfflineAccess: true
         redirectURIs:
           - "https://ceph.cph02.nicklasfrahm.dev/oauth2/callback"
-      - id: kaether
-        name: "kaether"
+      - id: kontinuum
+        name: "kontinuum"
         public: true
         redirectURIs:
           - "http://localhost:8080/app"


### PR DESCRIPTION
Renames the `kaether` static Dex client added in #359 to `kontinuum`.