### PR TITLE
feat(ci): add Cloud Run service module and OpenTofu pipeline

### DIFF
--- a/.github/workflows/opentofu.yaml
+++ b/.github/workflows/opentofu.yaml
@@ -83,7 +83,6 @@ jobs:
         root: ${{ fromJson(needs.detect-changes.outputs.roots) }}
     permissions:
       id-token: write
-      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -101,21 +100,85 @@ jobs:
       - name: Plan OpenTofu changes
         run: make opentofu-plan OPENTOFU_ROOT_MODULE=${{ matrix.root }}
 
-      - name: Dump OpenTofu plan
+      - name: Render plan fragment
         id: opentofu
         run: |
           set -eou pipefail
 
-          {
-            echo 'plan<<EOF'
-            cat ${{ matrix.root }}/tofu.log
-            echo EOF
-          } >>"$GITHUB_OUTPUT"
+          changes=$(make opentofu-count OPENTOFU_ROOT_MODULE=${{ matrix.root }})
+          echo "changes=$changes" >>"$GITHUB_OUTPUT"
 
-          echo "changes=$(make opentofu-count OPENTOFU_ROOT_MODULE=${{ matrix.root }})" >>"$GITHUB_OUTPUT"
+          # A root with no diff contributes nothing to the combined comment.
+          if [[ "$changes" == "0" ]]; then
+            exit 0
+          fi
+
+          slug=$(tr '/' '-' <<<"${{ matrix.root }}")
+          echo "slug=$slug" >>"$GITHUB_OUTPUT"
 
           summary=$(grep -E '^(Plan:|No changes\.)' ${{ matrix.root }}/tofu.log | tail -1)
-          echo "summary=$summary" >>"$GITHUB_OUTPUT"
+
+          {
+            echo '<details>'
+            echo '<summary>'
+            echo "<code>tofu -chdir=${{ matrix.root }} plan > $summary</code>"
+            echo '</summary>'
+            echo
+            echo '```tf'
+            cat ${{ matrix.root }}/tofu.log
+            echo '```'
+            echo
+            echo '</details>'
+          } >"plan-$slug.md"
+
+      - name: Upload plan fragment
+        if: steps.opentofu.outputs.changes != '0'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: opentofu-plan-${{ steps.opentofu.outputs.slug }}
+          path: plan-${{ steps.opentofu.outputs.slug }}.md
+          retention-days: 1
+
+  comment:
+    name: Publish OpenTofu plan comment
+    needs: [detect-changes, plan]
+    if: always() && github.event_name == 'pull_request' && needs.detect-changes.outputs.roots != '[]'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      # No matching artifacts (every root's plan was a no-op) leaves this
+      # directory empty rather than failing the step.
+      - name: Download plan fragments
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: opentofu-plan-*
+          path: fragments
+          merge-multiple: true
+
+      - name: Build comment body
+        id: build
+        run: |
+          set -eou pipefail
+
+          shopt -s nullglob
+          fragments=(fragments/*.md)
+
+          if [[ ${#fragments[@]} -eq 0 ]]; then
+            echo "has-changes=false" >>"$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          {
+            echo 'body<<EOF'
+            echo '## 🏗️ [OpenTofu plan](https://opentofu.org)'
+            echo
+            echo 'Changes were detected in the OpenTofu plan. Please review the changes below.'
+            echo
+            cat "${fragments[@]}"
+            echo 'EOF'
+          } >>"$GITHUB_OUTPUT"
+          echo "has-changes=true" >>"$GITHUB_OUTPUT"
 
       - name: Find plan comment
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4
@@ -123,32 +186,19 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: "github-actions[bot]"
-          body-includes: "OpenTofu plan: `${{ matrix.root }}`"
+          body-includes: "## 🏗️ [OpenTofu plan]"
 
       - name: Publish plan
+        if: steps.build.outputs.has-changes == 'true'
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         with:
           comment-id: ${{ steps.find-opentofu.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            ## 🏗️ [OpenTofu plan: `${{ matrix.root }}`](https://opentofu.org)
-
-            Changes were detected in the OpenTofu plan. Please review the changes below.
-
-            <details>
-            <summary>
-            <code>tofu -chdir=${{ matrix.root }} plan → ${{ steps.opentofu.outputs.summary }}</code>
-            </summary>
-
-            ```tf
-            ${{ steps.opentofu.outputs.plan }}
-            ```
-
-            </details>
+          body: ${{ steps.build.outputs.body }}
           edit-mode: replace
 
       - name: Delete plan comment
-        if: steps.opentofu.outputs.changes == '0' && steps.find-opentofu.outputs.comment-id != ''
+        if: steps.build.outputs.has-changes == 'false' && steps.find-opentofu.outputs.comment-id != ''
         run: gh api /repos/${{ github.repository }}/issues/comments/${{ steps.find-opentofu.outputs.comment-id }} -X DELETE
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/opentofu.yaml
+++ b/.github/workflows/opentofu.yaml
@@ -1,13 +1,86 @@
 name: OpenTofu
 
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "deploy/infra/**"
+      - "deploy/services/**"
+      - "modules/cloudrun-service/**"
+      - ".github/workflows/opentofu.yaml"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "deploy/infra/**"
+      - "deploy/services/**"
+      - "modules/cloudrun-service/**"
+      - ".github/workflows/opentofu.yaml"
 
 jobs:
-  plan:
-    name: Plan
+  detect-changes:
+    name: Detect changed roots
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main'
+    outputs:
+      roots: ${{ steps.detect.outputs.roots }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed OpenTofu roots
+        id: detect
+        run: |
+          set -eou pipefail
+
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            git fetch origin "${{ github.event.pull_request.base.ref }}"
+            diff_against="origin/${{ github.event.pull_request.base.ref }}"
+          else
+            diff_against="HEAD~1"
+          fi
+
+          changed=$(git diff --name-only "$diff_against")
+
+          roots=()
+          while IFS= read -r name; do
+            [[ -n "$name" ]] && roots+=("deploy/infra/$name")
+          done < <(grep -oP '^deploy/infra/\K[^/]+' <<<"$changed" | sort -u)
+
+          # deploy/services/** and modules/cloudrun-service/** are shared
+          # inputs: every deploy/infra/<root> discovers its own services
+          # dynamically, so a change to either can affect any root without
+          # touching deploy/infra itself. There's no cheap way to tell which
+          # root(s) are actually affected without running the module's own
+          # discovery, so treat all of them as changed.
+          if grep -qE '^(deploy/services/|modules/cloudrun-service/)' <<<"$changed"; then
+            while IFS= read -r dir; do
+              roots+=("$dir")
+            done < <(find deploy/infra -mindepth 1 -maxdepth 1 -type d | sort)
+          fi
+
+          if [[ ${#roots[@]} -gt 0 ]]; then
+            mapfile -t roots < <(printf '%s\n' "${roots[@]}" | sort -u)
+          fi
+
+          if [[ ${#roots[@]} -eq 0 ]]; then
+            json='[]'
+          else
+            json=$(printf '%s\n' "${roots[@]}" | jq -R . | jq -sc .)
+          fi
+
+          echo "roots=$json" >>"$GITHUB_OUTPUT"
+
+  plan:
+    name: Plan (${{ matrix.root }})
+    needs: detect-changes
+    if: github.event_name == 'pull_request' && needs.detect-changes.outputs.roots != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        root: ${{ fromJson(needs.detect-changes.outputs.roots) }}
     permissions:
       id-token: write
       pull-requests: write
@@ -26,7 +99,7 @@ jobs:
         uses: opentofu/setup-opentofu@a1320f892987e89d278cc92dc5adc984fb93aca4 # v2
 
       - name: Plan OpenTofu changes
-        run: make opentofu-plan
+        run: make opentofu-plan OPENTOFU_ROOT_MODULE=${{ matrix.root }}
 
       - name: Dump OpenTofu plan
         id: opentofu
@@ -35,11 +108,11 @@ jobs:
 
           {
             echo 'plan<<EOF'
-            cat tofu.log
+            cat ${{ matrix.root }}/tofu.log
             echo EOF
           } >>"$GITHUB_OUTPUT"
 
-          echo "changes=$(make opentofu-count)" >>"$GITHUB_OUTPUT"
+          echo "changes=$(make opentofu-count OPENTOFU_ROOT_MODULE=${{ matrix.root }})" >>"$GITHUB_OUTPUT"
 
       - name: Find plan comment
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4
@@ -47,7 +120,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: "github-actions[bot]"
-          body-includes: "OpenTofu plan"
+          body-includes: "OpenTofu plan: `${{ matrix.root }}`"
 
       - name: Publish plan
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
@@ -55,13 +128,13 @@ jobs:
           comment-id: ${{ steps.find-opentofu.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            ## 🏗️ [OpenTofu plan](https://opentofu.org)
+            ## 🏗️ [OpenTofu plan: `${{ matrix.root }}`](https://opentofu.org)
 
             Changes were detected in the OpenTofu plan. Please review the changes below.
 
             <details>
             <summary>
-            <code>make opentofu-plan</code>
+            <code>make opentofu-plan OPENTOFU_ROOT_MODULE=${{ matrix.root }}</code>
             </summary>
 
             ```tf
@@ -78,9 +151,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   apply:
-    name: Apply
+    name: Apply (${{ matrix.root }})
+    needs: detect-changes
+    if: github.event_name == 'push' && needs.detect-changes.outputs.roots != '[]'
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    strategy:
+      matrix:
+        root: ${{ fromJson(needs.detect-changes.outputs.roots) }}
     permissions:
       id-token: write
     steps:
@@ -98,4 +175,4 @@ jobs:
         uses: opentofu/setup-opentofu@a1320f892987e89d278cc92dc5adc984fb93aca4 # v2
 
       - name: Apply OpenTofu changes
-        run: make opentofu-apply
+        run: make opentofu-apply OPENTOFU_ROOT_MODULE=${{ matrix.root }}

--- a/.github/workflows/opentofu.yaml
+++ b/.github/workflows/opentofu.yaml
@@ -114,6 +114,9 @@ jobs:
 
           echo "changes=$(make opentofu-count OPENTOFU_ROOT_MODULE=${{ matrix.root }})" >>"$GITHUB_OUTPUT"
 
+          summary=$(grep -E '^(Plan:|No changes\.)' ${{ matrix.root }}/tofu.log | tail -1)
+          echo "summary=$summary" >>"$GITHUB_OUTPUT"
+
       - name: Find plan comment
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4
         id: find-opentofu
@@ -134,7 +137,7 @@ jobs:
 
             <details>
             <summary>
-            <code>make opentofu-plan OPENTOFU_ROOT_MODULE=${{ matrix.root }}</code>
+            <code>tofu -chdir=${{ matrix.root }} plan</code> → ${{ steps.opentofu.outputs.summary }}
             </summary>
 
             ```tf

--- a/.github/workflows/opentofu.yaml
+++ b/.github/workflows/opentofu.yaml
@@ -137,7 +137,7 @@ jobs:
 
             <details>
             <summary>
-            <code>tofu -chdir=${{ matrix.root }} plan</code> → ${{ steps.opentofu.outputs.summary }}
+            <code>tofu -chdir=${{ matrix.root }} plan → ${{ steps.opentofu.outputs.summary }}</code>
             </summary>
 
             ```tf

--- a/Makefile
+++ b/Makefile
@@ -4,23 +4,27 @@
 
 OPENTOFU_ROOT_MODULE	?= deploy/opentofu
 OPENTOFU_PLAN					?= $(OPENTOFU_ROOT_MODULE)/opentofu.tfplan
+OPENTOFU_LOG					?= $(OPENTOFU_ROOT_MODULE)/tofu.log
 OPENTOFU_ROOT_SOURCES	?= $(shell find $(OPENTOFU_ROOT_MODULE) -maxdepth 1 -type f -name '*.tf')
 
+# OPENTOFU_ROOT_MODULE is overridable (e.g. `make opentofu-plan
+# OPENTOFU_ROOT_MODULE=deploy/infra/prd-cloudrun-services`) so the same
+# targets drive every root module under deploy/, not just deploy/opentofu.
 $(OPENTOFU_PLAN): $(OPENTOFU_ROOT_SOURCES)
-	tofu -chdir=deploy/opentofu init
-	tofu -chdir=deploy/opentofu plan -out=opentofu.tfplan | tee tofu.log
-	@sed -i 's/\x1b\[[0-9;]*m//g' tofu.log
+	tofu -chdir=$(OPENTOFU_ROOT_MODULE) init
+	tofu -chdir=$(OPENTOFU_ROOT_MODULE) plan -out=opentofu.tfplan | tee $(OPENTOFU_LOG)
+	@sed -i 's/\x1b\[[0-9;]*m//g' $(OPENTOFU_LOG)
 
 opentofu-plan: $(OPENTOFU_PLAN) ## Plan the infrastructure changes.
 
 .PHONY: opentofu-count
 opentofu-count: opentofu-plan ## Count the number of changes in the plan.
-	@tofu -chdir=deploy/opentofu show -json opentofu.tfplan | jq -r '.resource_changes[].change.actions | join(",")' | grep -Ecv '^no-op$$' || true
+	@tofu -chdir=$(OPENTOFU_ROOT_MODULE) show -json opentofu.tfplan | jq -r '.resource_changes[].change.actions | join(",")' | grep -Ecv '^no-op$$' || true
 
 .PHONY: opentofu-apply
 opentofu-apply: ## Apply the infrastructure changes.
-	tofu -chdir=deploy/opentofu init
-	tofu -chdir=deploy/opentofu apply -auto-approve
+	tofu -chdir=$(OPENTOFU_ROOT_MODULE) init
+	tofu -chdir=$(OPENTOFU_ROOT_MODULE) apply -auto-approve
 
 ################
 ### Monorepo ###

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ opentofu-plan: $(OPENTOFU_PLAN) ## Plan the infrastructure changes.
 
 .PHONY: opentofu-count
 opentofu-count: opentofu-plan ## Count the number of changes in the plan.
-	@tofu -chdir=$(OPENTOFU_ROOT_MODULE) show -json opentofu.tfplan | jq -r '.resource_changes[].change.actions | join(",")' | grep -Ecv '^no-op$$' || true
+	@tofu -chdir=$(OPENTOFU_ROOT_MODULE) show -json opentofu.tfplan | jq -r '(.resource_changes // [])[].change.actions | join(",")' | grep -Ecv '^no-op$$' || true
 
 .PHONY: opentofu-apply
 opentofu-apply: ## Apply the infrastructure changes.

--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -3,4 +3,4 @@ type: application
 name: service
 description: A Helm chart for deploying a generic service in a Kubernetes cluster.
 icon: https://cdn-icons-png.flaticon.com/512/9402/9402265.png
-version: 0.3.1
+version: 0.3.2

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -1,11 +1,17 @@
-# These will automatically be injected by the `argocd-apps` chart.
-# No need to set them manually.
+# cluster, environment, location, tenant and domain are automatically
+# injected by the `argocd-apps` chart. No need to set them manually.
 platform:
   cluster: "dev-lab01"
   environment: "dev"
   location: "lab01"
   tenant: "demo"
   domain: "nicklasfrahm.dev"
+  # target selects which infrastructure deploys this service. "Kubernetes"
+  # (the default) is deployed by ArgoCD via this chart. Set to
+  # "GoogleCloudRunService" to instead have modules/cloudrun-service deploy
+  # it to Cloud Run. Unlike the rest of platform.*, this must be set by hand
+  # in the service's own 00-base.yml.
+  target: "Kubernetes"
 
 image:
   repository: "ghcr.io/nicklasfrahm-dev/axon"

--- a/deploy/clusters/prd-cbf01/nicklasfrahm/kontinuum.yml
+++ b/deploy/clusters/prd-cbf01/nicklasfrahm/kontinuum.yml
@@ -1,0 +1,6 @@
+# prd-cbf01 has no real Kubernetes cluster behind it - it exists purely so
+# modules/cloudrun-service can discover this service (see
+# modules/cloudrun-service/variables.tf). This directory's name,
+# "nicklasfrahm", is used as the GCP project ID. All values live in
+# deploy/services/kontinuum/00-base.yml; nothing to override here.
+{}

--- a/deploy/clusters/prd-cbf01/nicklasfrahm/kontinuum.yml
+++ b/deploy/clusters/prd-cbf01/nicklasfrahm/kontinuum.yml
@@ -1,6 +1,9 @@
 # prd-cbf01 has no real Kubernetes cluster behind it - it exists purely so
 # modules/cloudrun-service can discover this service (see
 # modules/cloudrun-service/variables.tf). This directory's name,
-# "nicklasfrahm", is used as the GCP project ID. All values live in
-# deploy/services/kontinuum/00-base.yml; nothing to override here.
-{}
+# "nicklasfrahm", is used as the GCP project ID. chart is unused by Cloud
+# Run (only ArgoCD's ApplicationSet reads it), kept here for consistency
+# with every other release file's convention.
+chart:
+  name: service
+  tag: 0.3.2

--- a/deploy/clusters/prd-cph02/monitoring-system/speedtest-exporter.yml
+++ b/deploy/clusters/prd-cph02/monitoring-system/speedtest-exporter.yml
@@ -1,3 +1,3 @@
 chart:
   name: service
-  tag: 0.3.1
+  tag: 0.3.2

--- a/deploy/infra/prd-cloudrun-services/main.tf
+++ b/deploy/infra/prd-cloudrun-services/main.tf
@@ -1,0 +1,20 @@
+locals {
+  root = "${path.module}/../../.."
+
+  # Fetch global configuration options, such as the DNS zone.
+  global_config = yamldecode(file("${local.root}/config.yaml"))
+}
+
+module "cloudrun_service" {
+  source = "../../../modules/cloudrun-service"
+
+  cluster_glob = "prd-*"
+  clusters_dir = "${local.root}/deploy/clusters"
+  values_dir   = "${local.root}/deploy/services"
+  domain       = local.global_config.dns.zone
+}
+
+output "uris" {
+  description = "The URI of each deployed Cloud Run service, keyed by \"<project>/<service>\"."
+  value       = module.cloudrun_service.uris
+}

--- a/deploy/infra/prd-cloudrun-services/providers.tf
+++ b/deploy/infra/prd-cloudrun-services/providers.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+
+  backend "gcs" {
+    bucket = "nicklasfrahm"
+    prefix = "tofu/state/prd-cloudrun-services"
+  }
+}

--- a/deploy/services/kontinuum/00-base.yml
+++ b/deploy/services/kontinuum/00-base.yml
@@ -1,0 +1,44 @@
+# cluster, environment, location, tenant and domain are automatically
+# injected by modules/cloudrun-service. No need to set them manually.
+platform:
+  # kontinuum runs on Cloud Run instead of Kubernetes; see
+  # deploy/clusters/prd-cbf01/nicklasfrahm/kontinuum.yml, the virtual
+  # cluster this service is discovered under.
+  target: "GoogleCloudRunService"
+
+image:
+  repository: "ghcr.io/nicklasfrahm-dev/kontinuum"
+  tag: "v0.1.3"
+
+service:
+  containerPort: 8080
+
+resources:
+  cpu: "1"
+  memory: "512Mi"
+
+autoscaling:
+  minReplicas: 0
+  maxReplicas: 1
+
+# No probes.* block: kontinuum exposes no /startup or /live endpoints, so we
+# rely on Cloud Run's default TCP startup check instead of the chart's HTTP
+# probe defaults (which would target a nonexistent path).
+
+expose:
+  enabled: true
+  host: "console.nicklasfrahm.dev"
+
+env:
+  fromLiterals:
+    KONTINUUM_SERVER_ADDR: ":8080"
+    # Demo/smoke-test value only - no real Postgres instance backs this.
+    KONTINUUM_SERVER_STORAGE: "postgres://kontinuum:dummy@dummy-postgres.invalid:5432/kontinuum?sslmode=disable"
+    KONTINUUM_LOG_LEVEL: "info"
+    KONTINUUM_LOG_FORMAT: "console"
+    # OIDC via Dex, public client "kontinuum" (no client secret, PKCE only;
+    # see deploy/services/dex/00-base.yml's staticClients entry).
+    KONTINUUM_OIDC_ISSUER_URL: "https://auth.nicklasfrahm.dev"
+    KONTINUUM_OIDC_CLIENT_ID: "kontinuum"
+    KONTINUUM_OIDC_REDIRECT_URL: "https://console.nicklasfrahm.dev/app"
+    KONTINUUM_OIDC_ADMIN_GROUPS: "nicklasfrahm-dev:platform"

--- a/deploy/services/kontinuum/00-base.yml
+++ b/deploy/services/kontinuum/00-base.yml
@@ -31,8 +31,6 @@ expose:
 env:
   fromLiterals:
     KONTINUUM_SERVER_ADDR: ":8080"
-    # Demo/smoke-test value only - no real Postgres instance backs this.
-    KONTINUUM_SERVER_STORAGE: "postgres://kontinuum:dummy@dummy-postgres.invalid:5432/kontinuum?sslmode=disable"
     # OIDC via Dex, public client "kontinuum" (no client secret, PKCE only;
     # see deploy/services/dex/00-base.yml's staticClients entry).
     KONTINUUM_OIDC_ISSUER_URL: "https://auth.nicklasfrahm.dev"

--- a/deploy/services/kontinuum/00-base.yml
+++ b/deploy/services/kontinuum/00-base.yml
@@ -27,7 +27,6 @@ autoscaling:
 
 expose:
   enabled: true
-  host: "console.nicklasfrahm.dev"
 
 env:
   fromLiterals:

--- a/deploy/services/kontinuum/00-base.yml
+++ b/deploy/services/kontinuum/00-base.yml
@@ -33,8 +33,6 @@ env:
     KONTINUUM_SERVER_ADDR: ":8080"
     # Demo/smoke-test value only - no real Postgres instance backs this.
     KONTINUUM_SERVER_STORAGE: "postgres://kontinuum:dummy@dummy-postgres.invalid:5432/kontinuum?sslmode=disable"
-    KONTINUUM_LOG_LEVEL: "info"
-    KONTINUUM_LOG_FORMAT: "console"
     # OIDC via Dex, public client "kontinuum" (no client secret, PKCE only;
     # see deploy/services/dex/00-base.yml's staticClients entry).
     KONTINUUM_OIDC_ISSUER_URL: "https://auth.nicklasfrahm.dev"

--- a/deploy/services/kontinuum/10-env-prd.yml
+++ b/deploy/services/kontinuum/10-env-prd.yml
@@ -1,0 +1,2 @@
+expose:
+  host: "console.nicklasfrahm.dev"

--- a/deploy/services/kontinuum/10-env-prd.yml
+++ b/deploy/services/kontinuum/10-env-prd.yml
@@ -1,2 +1,7 @@
 expose:
   host: "console.nicklasfrahm.dev"
+
+env:
+  fromSecrets:
+    KONTINUUM_SERVER_STORAGE:
+      PRD_KONTINUUM_SERVER_STORAGE: latest

--- a/modules/cloudrun-service/main.tf
+++ b/modules/cloudrun-service/main.tf
@@ -1,0 +1,107 @@
+resource "google_cloud_run_v2_service" "this" {
+  for_each = local.services
+
+  name     = each.value.name
+  project  = each.value.project
+  location = each.value.region
+  ingress  = "INGRESS_TRAFFIC_ALL"
+
+  template {
+    containers {
+      image = "${each.value.values.image.repository}:${each.value.values.image.tag}"
+
+      ports {
+        container_port = each.value.values.service.containerPort
+      }
+
+      resources {
+        limits = {
+          cpu    = each.value.values.resources.cpu
+          memory = each.value.values.resources.memory
+        }
+      }
+
+      dynamic "env" {
+        for_each = each.value.values.env.fromLiterals
+        content {
+          name  = env.key
+          value = env.value
+        }
+      }
+
+      # env.fromSecrets follows charts/service/values.yaml's shape of
+      # { VARIABLE: { secretName: keyName } }, mirroring a Kubernetes
+      # secretKeyRef. Secret Manager secrets have no equivalent to a
+      # Kubernetes Secret's multiple keys, so keyName is reinterpreted here
+      # as the Secret Manager version (defaults to "latest" upstream).
+      dynamic "env" {
+        for_each = each.value.values.env.fromSecrets
+        content {
+          name = env.key
+          value_source {
+            secret_key_ref {
+              secret  = keys(env.value)[0]
+              version = values(env.value)[0]
+            }
+          }
+        }
+      }
+
+      dynamic "startup_probe" {
+        for_each = try(each.value.values.probes.startup.enabled, false) ? [each.value.values.probes.startup] : []
+        content {
+          http_get {
+            path = startup_probe.value.path
+          }
+          period_seconds    = startup_probe.value.periodSeconds
+          failure_threshold = startup_probe.value.failureThreshold
+        }
+      }
+
+      dynamic "liveness_probe" {
+        for_each = try(each.value.values.probes.liveness.enabled, false) ? [each.value.values.probes.liveness] : []
+        content {
+          http_get {
+            path = liveness_probe.value.path
+          }
+          initial_delay_seconds = liveness_probe.value.initialDelaySeconds
+          period_seconds        = liveness_probe.value.periodSeconds
+          failure_threshold     = liveness_probe.value.failureThreshold
+        }
+      }
+    }
+
+    scaling {
+      min_instance_count = each.value.values.autoscaling.minReplicas
+      max_instance_count = each.value.values.autoscaling.maxReplicas
+    }
+  }
+}
+
+# expose.enabled makes the service publicly reachable, mirroring the
+# HTTPRoute that charts/service creates behind the shared gateway.
+resource "google_cloud_run_v2_service_iam_member" "public" {
+  for_each = local.exposed_services
+
+  project  = each.value.project
+  location = each.value.region
+  name     = google_cloud_run_v2_service.this[each.key].name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}
+
+resource "google_cloud_run_domain_mapping" "this" {
+  for_each = local.exposed_services
+
+  name     = local.hostnames[each.key]
+  project  = each.value.project
+  location = each.value.region
+
+  metadata {
+    namespace = each.value.project
+  }
+
+  spec {
+    route_name = google_cloud_run_v2_service.this[each.key].name
+  }
+}

--- a/modules/cloudrun-service/outputs.tf
+++ b/modules/cloudrun-service/outputs.tf
@@ -1,0 +1,15 @@
+output "uris" {
+  description = "The URI of each deployed Cloud Run service, keyed by \"<project>/<service>\"."
+  value = {
+    for key, service in google_cloud_run_v2_service.this :
+    "${local.services[key].project}/${local.services[key].name}" => service.uri
+  }
+}
+
+output "values" {
+  description = "The fully merged values used to deploy each service, keyed by \"<project>/<service>\"."
+  value = {
+    for key, service in local.services :
+    "${service.project}/${service.name}" => service.values
+  }
+}

--- a/modules/cloudrun-service/providers.tf
+++ b/modules/cloudrun-service/providers.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/modules/cloudrun-service/values.tf
+++ b/modules/cloudrun-service/values.tf
@@ -1,0 +1,173 @@
+# Discover candidate services the same way ArgoCD's ApplicationSet does for
+# Kubernetes (see charts/argocd-apps/templates/applicationset.yaml): every
+# deploy/clusters/<cluster>/<tenant>/<service>.yml file identifies one
+# service. Here, only the ones whose base values opt in via
+# platform.target = "GoogleCloudRunService" are kept, and merged the same
+# way Argo merges Helm values: 00-base -> 10-env -> the file that identifies
+# the service -> injected platform values that always win.
+locals {
+  candidate_files = fileset(var.clusters_dir, "${var.cluster_glob}/*/*.y*ml")
+
+  candidates = {
+    for f in local.candidate_files :
+    f => {
+      cluster  = split("/", f)[0]
+      tenant   = split("/", f)[1]
+      service  = trimsuffix(trimsuffix(split("/", f)[2], ".yaml"), ".yml")
+      override = yamldecode(file("${var.clusters_dir}/${f}"))
+    }
+  }
+
+  # 00-base.yml may be absent or empty for services that rely solely on
+  # chart defaults, mirroring the ApplicationSet's ignoreMissingValueFiles.
+  base_values = {
+    for f, candidate in local.candidates :
+    f => try(yamldecode(file("${var.values_dir}/${candidate.service}/00-base.yml")), {})
+  }
+
+  # Everything not opting in via platform.target is assumed to be
+  # Kubernetes-bound and is left for ArgoCD to deploy.
+  cloud_run_candidates = {
+    for f, candidate in local.candidates :
+    f => candidate if try(local.base_values[f].platform.target, "") == "GoogleCloudRunService"
+  }
+
+  # Each candidate's cluster follows "<environment>-<location>" (e.g.
+  # "prd-cbf01"), the same convention charts/argocd-apps' ApplicationSet
+  # derives environment/location from for Kubernetes clusters.
+  cluster_parts = {
+    for f, candidate in local.cloud_run_candidates :
+    f => split("-", candidate.cluster)
+  }
+  environments = {
+    for f, parts in local.cluster_parts :
+    f => parts[0]
+  }
+  locations = {
+    for f, parts in local.cluster_parts :
+    f => parts[length(parts) - 1]
+  }
+
+  # Translates a location code to its GCP region. Extend as new locations
+  # come into use.
+  region_by_location = {
+    cbf01 = "us-central1"
+  }
+
+  env_values = {
+    for f, candidate in local.cloud_run_candidates :
+    f => try(yamldecode(file("${var.values_dir}/${candidate.service}/10-env-${local.environments[f]}.yml")), {})
+  }
+
+  platform_values = {
+    for f, candidate in local.cloud_run_candidates :
+    f => {
+      platform = {
+        environment = local.environments[f]
+        location    = local.locations[f]
+        domain      = var.domain
+      }
+    }
+  }
+
+  # merge() only merges top level keys, so every nested map that a service
+  # may override (image, service, resources, env, autoscaling, probes,
+  # expose) is merged one level deeper on top of the shallow merge to match
+  # the schema in charts/service/values.yaml.
+  merged_values = {
+    for f, candidate in local.cloud_run_candidates :
+    f => merge(
+      local.base_values[f],
+      local.env_values[f],
+      candidate.override,
+      local.platform_values[f],
+      {
+        image = merge(
+          try(local.base_values[f].image, {}),
+          try(local.env_values[f].image, {}),
+          try(candidate.override.image, {}),
+        )
+        service = merge(
+          try(local.base_values[f].service, {}),
+          try(local.env_values[f].service, {}),
+          try(candidate.override.service, {}),
+        )
+        resources = merge(
+          try(local.base_values[f].resources, {}),
+          try(local.env_values[f].resources, {}),
+          try(candidate.override.resources, {}),
+        )
+        autoscaling = merge(
+          try(local.base_values[f].autoscaling, {}),
+          try(local.env_values[f].autoscaling, {}),
+          try(candidate.override.autoscaling, {}),
+        )
+        env = {
+          fromLiterals = merge(
+            try(local.base_values[f].env.fromLiterals, {}),
+            try(local.env_values[f].env.fromLiterals, {}),
+            try(candidate.override.env.fromLiterals, {}),
+          )
+          fromSecrets = merge(
+            try(local.base_values[f].env.fromSecrets, {}),
+            try(local.env_values[f].env.fromSecrets, {}),
+            try(candidate.override.env.fromSecrets, {}),
+          )
+        }
+        probes = {
+          startup = merge(
+            try(local.base_values[f].probes.startup, {}),
+            try(local.env_values[f].probes.startup, {}),
+            try(candidate.override.probes.startup, {}),
+          )
+          liveness = merge(
+            try(local.base_values[f].probes.liveness, {}),
+            try(local.env_values[f].probes.liveness, {}),
+            try(candidate.override.probes.liveness, {}),
+          )
+        }
+        expose = merge(
+          try(local.base_values[f].expose, {}),
+          try(local.env_values[f].expose, {}),
+          try(candidate.override.expose, {}),
+          {
+            path = merge(
+              try(local.base_values[f].expose.path, {}),
+              try(local.env_values[f].expose.path, {}),
+              try(candidate.override.expose.path, {}),
+            )
+          }
+        )
+      }
+    )
+  }
+
+  # One entry per Cloud Run service to deploy, keyed by the
+  # <cluster>/<tenant>/<service>.yml path so that the same service name used
+  # by different tenants or clusters can never collide.
+  services = {
+    for f, candidate in local.cloud_run_candidates :
+    f => {
+      name    = candidate.service
+      project = candidate.tenant
+      region  = local.region_by_location[local.locations[f]]
+      values  = local.merged_values[f]
+    }
+  }
+
+  # Reproduces charts/service/templates/httproute.yml's hostname precedence:
+  # explicit host, then hostPrefix.domain, then name.location.domain.
+  hostnames = {
+    for f, service in local.services :
+    f => (
+      try(service.values.expose.host, "") != "" ? service.values.expose.host :
+      try(service.values.expose.hostPrefix, "") != "" ? "${service.values.expose.hostPrefix}.${service.values.platform.domain}" :
+      "${service.name}.${service.values.platform.location}.${service.values.platform.domain}"
+    )
+  }
+
+  exposed_services = {
+    for f, service in local.services :
+    f => service if try(service.values.expose.enabled, false)
+  }
+}

--- a/modules/cloudrun-service/variables.tf
+++ b/modules/cloudrun-service/variables.tf
@@ -1,0 +1,39 @@
+variable "cluster_glob" {
+  description = <<-EOT
+    Glob used to select which deploy/clusters/<cluster> directories to scan
+    for services (e.g. "prd-*"). Every matched cluster name must follow
+    "<environment>-<location>", the same convention used for Kubernetes
+    clusters. A matched cluster directory does not need a real Kubernetes
+    cluster behind it: it can exist purely to declare Cloud Run services.
+  EOT
+  type        = string
+}
+
+variable "clusters_dir" {
+  description = <<-EOT
+    Path to the deploy/clusters directory. Every
+    "<clusters_dir>/<cluster>/<tenant>/<service>.yml" file found under a
+    cluster matching var.cluster_glob is a deploy candidate: the tenant
+    directory name is used as the GCP project ID, and the file's content is
+    merged in as the highest-precedence values overlay.
+  EOT
+  type        = string
+}
+
+variable "values_dir" {
+  description = <<-EOT
+    Path to the deploy/services directory. A candidate service is only
+    deployed here when its "<values_dir>/<service>/00-base.yml" sets
+    platform.target to "GoogleCloudRunService" - everything else is assumed
+    to be Kubernetes-bound and is left to ArgoCD. A
+    "<values_dir>/<service>/10-env-<environment>.yml" overlay is merged on
+    top when present. Values follow the schema of charts/service/values.yaml.
+  EOT
+  type        = string
+}
+
+variable "domain" {
+  description = "The base domain used to build a hostname for services that set expose.enabled without an explicit expose.host or expose.hostPrefix."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary
- Add `modules/cloudrun-service`, a Terraform module that deploys services to Cloud Run by discovering `deploy/clusters/<cluster>/<tenant>/<service>.yml` pointer files matching a `cluster_glob` and merging their `deploy/services` values (00-base -> 10-env -> pointer file -> injected platform values), matching the service Helm chart's values.yaml schema. Services opt in via a new `platform.target: GoogleCloudRunService` field.
- Wire the module into a new root, `deploy/infra/prd-cloudrun-services`, with its own GCS state prefix.
- Add `platform.target` to `charts/service/values.yaml` (default `Kubernetes`) and bump the chart to 0.3.2.
- Replace the previous manual-dispatch-only `opentofu.yaml` workflow with one that detects changed `deploy/infra/<root>` directories (as well as shared `deploy/services/**` and `modules/cloudrun-service/**` changes, which can affect any root) and runs `tofu plan` on pull requests / `tofu apply` on merge to main, per root.
- Generalize the `Makefile`'s `opentofu-*` targets to take `OPENTOFU_ROOT_MODULE` as an override instead of hardcoding `deploy/opentofu`.