### PR TITLE
fix(config): replace speedtest-exporter image

### DIFF
--- a/deploy/services/speedtest-exporter/00-base.yml
+++ b/deploy/services/speedtest-exporter/00-base.yml
@@ -1,7 +1,7 @@
 # Image configuration - override default image
 image:
-  repository: "ghcr.io/nicklasfrahm/prometheus-speedtest-exporter"
-  tag: "v1.1.2"
+  repository: "ghcr.io/nicklasfrahm-dev/prometheus-speedtest-exporter"
+  tag: "v1.1.8"
 
 # Service configuration - override default port
 service:


### PR DESCRIPTION
## Summary
- Move speedtest-exporter image from `ghcr.io/nicklasfrahm/prometheus-speedtest-exporter` to `ghcr.io/nicklasfrahm-dev/prometheus-speedtest-exporter`
- Bump tag from `v1.1.2` to `v1.1.8`