### PR TITLE
fix(ci): pin actions to SHA and repair blocked release workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 15
     commit-message:
-      prefix: "chore(ci)"
+      prefix: "fix(deps)"
     groups:
       actions:
         patterns:
@@ -15,6 +17,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 15
     commit-message:
       prefix: "fix(deps)"
     groups:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
 
@@ -70,7 +70,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Check conventional commit format
         env:
@@ -43,10 +43,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Go
-        uses: actions/setup-go@v6.5.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
 
@@ -54,7 +54,7 @@ jobs:
         run: go generate ./...
 
       - name: Run linter
-        uses: golangci/golangci-lint-action@v9.3.0
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: latest
           install-mode: goinstall
@@ -67,10 +67,10 @@ jobs:
       pull-requests: write
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Go
-        uses: actions/setup-go@v6.5.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
 
@@ -78,7 +78,7 @@ jobs:
         run: go generate ./...
 
       - name: Report coverage
-        uses: gwatts/go-coverage-action@v2.0.0
+        uses: nicklasfrahm-dev/go-coverage-action@e9e14fc9f3b9e3577c4f31e9a5620249b2d8b171 # v2.0.4
         with:
           fail-coverage: never
           # Attribute cross-package coverage so integration tests in cmd/wallet

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -22,19 +22,19 @@ jobs:
       issues: write
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: pr
 
       - name: Checkout main
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: main
           path: main
 
       - name: Setup Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
 
       - name: Diff charts
         id: diff
@@ -100,7 +100,7 @@ jobs:
           fi
 
       - name: Upload diffs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         id: diff-upload
         if: steps.diff.outputs.changed != '0' && steps.diff.outputs.long == '1'
         with:
@@ -128,7 +128,7 @@ jobs:
           fi
 
       - name: Find diff comment
-        uses: peter-evans/find-comment@v4
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4
         id: find-diff
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -136,7 +136,7 @@ jobs:
           body-includes: "Chart changes"
 
       - name: Publish chart changes
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         if: steps.diff.outputs.changed != '0'
         with:
           comment-id: ${{ steps.find-diff.outputs.comment-id }}
@@ -210,7 +210,7 @@ jobs:
           } >>"$GITHUB_OUTPUT"
 
       - name: Find pending version updates comment
-        uses: peter-evans/find-comment@v4
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4
         id: find-version
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -218,7 +218,7 @@ jobs:
           body-includes: "Pending version updates"
 
       - name: Publish pending version updates
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         if: steps.version.outputs.pending != '0'
         with:
           comment-id: ${{ steps.find-version.outputs.comment-id }}
@@ -265,7 +265,7 @@ jobs:
           } >>"$GITHUB_OUTPUT"
 
       - name: Find lint comment
-        uses: peter-evans/find-comment@v4
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4
         id: find-lint
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -273,7 +273,7 @@ jobs:
           body-includes: "Helm linting"
 
       - name: Publish lint results
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         if: steps.lint.outputs.result != '0'
         with:
           comment-id: ${{ steps.find-lint.outputs.comment-id }}
@@ -313,15 +313,15 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 2
 
       - name: Setup Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
 
       - name: Setup ORAS
-        uses: oras-project/setup-oras@v2
+        uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2
 
       - name: Publish charts
         run: |

--- a/.github/workflows/opentofu.yaml
+++ b/.github/workflows/opentofu.yaml
@@ -13,17 +13,17 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
           workload_identity_provider: ${{ vars.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
           project_id: ${{ vars.GOOGLE_PROJECT }}
           service_account: ${{ vars.GOOGLE_SERVICE_ACCOUNT }}
 
       - name: Setup OpenTofu
-        uses: opentofu/setup-opentofu@v2
+        uses: opentofu/setup-opentofu@a1320f892987e89d278cc92dc5adc984fb93aca4 # v2
 
       - name: Plan OpenTofu changes
         run: make opentofu-plan
@@ -42,7 +42,7 @@ jobs:
           echo "changes=$(make opentofu-count)" >>"$GITHUB_OUTPUT"
 
       - name: Find plan comment
-        uses: peter-evans/find-comment@v4
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4
         id: find-opentofu
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -50,7 +50,7 @@ jobs:
           body-includes: "OpenTofu plan"
 
       - name: Publish plan
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         with:
           comment-id: ${{ steps.find-opentofu.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
@@ -85,17 +85,17 @@ jobs:
       id-token: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
           workload_identity_provider: ${{ vars.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
           project_id: ${{ vars.GOOGLE_PROJECT }}
           service_account: ${{ vars.GOOGLE_SERVICE_ACCOUNT }}
 
       - name: Setup OpenTofu
-        uses: opentofu/setup-opentofu@v2
+        uses: opentofu/setup-opentofu@a1320f892987e89d278cc92dc5adc984fb93aca4 # v2
 
       - name: Apply OpenTofu changes
         run: make opentofu-apply

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,32 +14,53 @@ jobs:
       issues: write
       pull-requests: write
     outputs:
-      released: ${{ steps.release.outputs.new-release-published }}
-      version: ${{ steps.release.outputs.release-version }}
-      tag: ${{ steps.release.outputs.git-tag }}
+      released: ${{ steps.outputs.outputs.released }}
+      version: ${{ steps.outputs.outputs.version }}
+      tag: ${{ steps.outputs.outputs.tag }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
-      - name: Create release
-        id: release
-        uses: codfish/semantic-release-action@v5.0.0
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          repository-url: https://github.com/${{ github.repository }}
-          branches: |
-            [
-              "main"
-            ]
-          plugins: |
-            [
+          node-version: "24"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm install --minimum-release-age=21600 semantic-release @semantic-release/commit-analyzer @semantic-release/release-notes-generator @semantic-release/github
+
+      - name: Create config
+        run: |
+          cat <<EOF > .releaserc.json
+          {
+            "branches": ["main"],
+            "plugins": [
               "@semantic-release/commit-analyzer",
               "@semantic-release/release-notes-generator",
               "@semantic-release/github"
             ]
+          }
+          EOF
+
+      - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npx --minimum-release-age=21600 semantic-release
+
+      - name: Resolve release outputs
+        id: outputs
+        run: |
+          set -eou pipefail
+          if tag=$(git describe --tags --exact-match HEAD 2>/dev/null); then
+            echo "released=true" >>"$GITHUB_OUTPUT"
+            echo "version=${tag#v}" >>"$GITHUB_OUTPUT"
+            echo "tag=$tag" >>"$GITHUB_OUTPUT"
+          else
+            echo "released=false" >>"$GITHUB_OUTPUT"
+          fi
 
   discover:
     name: Discover services
@@ -48,7 +69,7 @@ jobs:
       matrix: ${{ steps.list.outputs.matrix }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: List services
         id: list
@@ -75,12 +96,12 @@ jobs:
       matrix: ${{ fromJson(needs.discover.outputs.matrix) }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v6.5.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
 
@@ -129,15 +150,15 @@ jobs:
 
       - name: Set up QEMU
         if: steps.changed.outputs.changed == 'true'
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
 
       - name: Set up Docker Buildx
         if: steps.changed.outputs.changed == 'true'
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Log in to GitHub Container Registry
         if: steps.changed.outputs.changed == 'true'
-        uses: docker/login-action@v4
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -170,7 +191,7 @@ jobs:
 
       - name: Build and push container image
         if: steps.changed.outputs.changed == 'true'
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: ${{ steps.containerfile.outputs.path }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -101,7 +101,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
 

--- a/actions/deploy/action.yml
+++ b/actions/deploy/action.yml
@@ -21,7 +21,7 @@ runs:
   using: composite
   steps:
     - name: Checkout configuration repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
       with:
         repository: nicklasfrahm-dev/platform
         ssh-key: ${{ inputs.github-ssh-key }}
@@ -58,7 +58,7 @@ runs:
         fi
 
     - name: Install yq
-      uses: dcarbone/install-yq-action@4075b4dca348d74bd83f2bf82d30f25d7c54539b
+      uses: dcarbone/install-yq-action@4075b4dca348d74bd83f2bf82d30f25d7c54539b # v1.3.1
 
     - name: Update image tag in environment file
       shell: bash


### PR DESCRIPTION
## Summary
- Pin every third-party GitHub Action to a commit SHA, with a comment referencing the source tag, across `ci.yaml`, `helm.yaml`, `opentofu.yaml`, `release.yaml`, and `actions/deploy/action.yml`.
- `nicklasfrahm-dev/platform/actions/deploy@main` (deploy.yaml) is left unpinned intentionally — it's a same-repo self-reference, so pinning it is circular and doesn't carry the supply-chain risk external actions do.
- `codfish/semantic-release-action` is blocked by GitHub for a ToS violation, so the release job now runs `semantic-release` directly via `npm install` + `npx`, mirroring the approach in `nicklasfrahm-dev/go-coverage-action`'s own release workflow, with a 15-day minimum package release age (`--minimum-release-age=21600`). The job re-derives its `released`/`version`/`tag` outputs from git so the downstream publish job is unaffected.
- Swap the coverage step in `ci.yaml` from upstream `gwatts/go-coverage-action` to our fork, `nicklasfrahm-dev/go-coverage-action`.
- `dependabot.yml`: both ecosystems now have a 15-day cooldown (`cooldown.default-days: 15`) and a unified `fix(deps)` commit prefix (previously `github-actions` used `chore(ci)`).