### PR TITLE
fix(ci): remove npm cache from release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,6 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24"
-          cache: "npm"
 
       - name: Install dependencies
         run: npm install --minimum-release-age=21600 semantic-release @semantic-release/commit-analyzer @semantic-release/release-notes-generator @semantic-release/github


### PR DESCRIPTION
## Summary
- `actions/setup-node`'s `cache: npm` requires a lock file (package-lock.json/npm-shrinkwrap.json/yarn.lock) to key its cache, but this repo has no `package.json` — the release job installs `semantic-release` and plugins ad hoc via `npm install`
- This caused the "Create release" job to fail at the "Set up Node.js" step with `Dependencies lock file is not found`, blocking every release run

Fixes: https://github.com/nicklasfrahm-dev/platform/actions/runs/30168509089/job/89705484081