### PR TITLE
fix(config): give each Cloud Run service its own runtime identity

### DIFF
--- a/.github/workflows/opentofu.yaml
+++ b/.github/workflows/opentofu.yaml
@@ -84,10 +84,11 @@ jobs:
     permissions:
       id-token: write
     env:
-      # Picked up by modules/cloudrun-service's `deployer` variable, so it
-      # can grant this same principal roles/iam.serviceAccountUser on every
-      # Cloud Run service's runtime identity.
-      TF_VAR_deployer: ${{ vars.GOOGLE_SERVICE_ACCOUNT }}
+      # Picked up by modules/cloudrun-service's `DEPLOYER_SERVICE_ACCOUNT`
+      # variable, so it can grant this same principal
+      # roles/iam.serviceAccountUser on every Cloud Run service's runtime
+      # identity.
+      TF_VAR_DEPLOYER_SERVICE_ACCOUNT: ${{ vars.GOOGLE_SERVICE_ACCOUNT }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -219,7 +220,7 @@ jobs:
     permissions:
       id-token: write
     env:
-      TF_VAR_deployer: ${{ vars.GOOGLE_SERVICE_ACCOUNT }}
+      TF_VAR_DEPLOYER_SERVICE_ACCOUNT: ${{ vars.GOOGLE_SERVICE_ACCOUNT }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/opentofu.yaml
+++ b/.github/workflows/opentofu.yaml
@@ -83,6 +83,11 @@ jobs:
         root: ${{ fromJson(needs.detect-changes.outputs.roots) }}
     permissions:
       id-token: write
+    env:
+      # Picked up by modules/cloudrun-service's `deployer` variable, so it
+      # can grant this same principal roles/iam.serviceAccountUser on every
+      # Cloud Run service's runtime identity.
+      TF_VAR_deployer: ${{ vars.GOOGLE_SERVICE_ACCOUNT }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -213,6 +218,8 @@ jobs:
         root: ${{ fromJson(needs.detect-changes.outputs.roots) }}
     permissions:
       id-token: write
+    env:
+      TF_VAR_deployer: ${{ vars.GOOGLE_SERVICE_ACCOUNT }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/deploy/infra/prd-cloudrun-services/main.tf
+++ b/deploy/infra/prd-cloudrun-services/main.tf
@@ -12,6 +12,7 @@ module "cloudrun_service" {
   clusters_dir = "${local.root}/deploy/clusters"
   values_dir   = "${local.root}/deploy/services"
   domain       = local.global_config.dns.zone
+  deployer     = var.deployer
 }
 
 output "uris" {

--- a/deploy/infra/prd-cloudrun-services/main.tf
+++ b/deploy/infra/prd-cloudrun-services/main.tf
@@ -8,11 +8,11 @@ locals {
 module "cloudrun_service" {
   source = "../../../modules/cloudrun-service"
 
-  cluster_glob = "prd-*"
-  clusters_dir = "${local.root}/deploy/clusters"
-  values_dir   = "${local.root}/deploy/services"
-  domain       = local.global_config.dns.zone
-  deployer     = var.deployer
+  cluster_glob             = "prd-*"
+  clusters_dir             = "${local.root}/deploy/clusters"
+  values_dir               = "${local.root}/deploy/services"
+  domain                   = local.global_config.dns.zone
+  DEPLOYER_SERVICE_ACCOUNT = var.DEPLOYER_SERVICE_ACCOUNT
 }
 
 output "uris" {

--- a/deploy/infra/prd-cloudrun-services/variables.tf
+++ b/deploy/infra/prd-cloudrun-services/variables.tf
@@ -1,0 +1,4 @@
+variable "deployer" {
+  description = "Email of the principal running `tofu apply` (see modules/cloudrun-service's variable of the same name). Set via TF_VAR_deployer in CI."
+  type        = string
+}

--- a/deploy/infra/prd-cloudrun-services/variables.tf
+++ b/deploy/infra/prd-cloudrun-services/variables.tf
@@ -1,4 +1,4 @@
-variable "deployer" {
-  description = "Email of the principal running `tofu apply` (see modules/cloudrun-service's variable of the same name). Set via TF_VAR_deployer in CI."
+variable "DEPLOYER_SERVICE_ACCOUNT" {
+  description = "Email of the principal running `tofu apply` (see modules/cloudrun-service's variable of the same name). Set via TF_VAR_DEPLOYER_SERVICE_ACCOUNT in CI."
   type        = string
 }

--- a/modules/cloudrun-service/main.tf
+++ b/modules/cloudrun-service/main.tf
@@ -1,3 +1,39 @@
+# A dedicated runtime identity per service, rather than falling back to the
+# project's default Compute Engine service account, so each service's
+# permissions (e.g. the Secret Manager grants below) stay scoped to what
+# that service actually needs.
+resource "google_service_account" "this" {
+  for_each = local.services
+
+  project      = each.value.project
+  account_id   = "svc-${each.value.name}"
+  display_name = "Cloud Run runtime identity for ${each.value.name}"
+}
+
+# Cloud Run V2 requires the deploying principal to be able to act as the
+# identity it assigns to the service, which isn't implied by any role
+# var.deployer holds on the project itself.
+resource "google_service_account_iam_member" "deployer_can_act_as" {
+  for_each = local.services
+
+  service_account_id = google_service_account.this[each.key].name
+  role                = "roles/iam.serviceAccountUser"
+  member              = "serviceAccount:${var.deployer}"
+}
+
+# Grants each service's runtime identity access to read the Secret Manager
+# secrets it references via env.fromSecrets. The secrets themselves are
+# created out of band (e.g. via the GCP console) - this only grants access
+# to ones that already exist.
+resource "google_secret_manager_secret_iam_member" "runtime_can_access" {
+  for_each = local.secret_grants
+
+  project   = each.value.project
+  secret_id = each.value.secret
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.this[each.value.service].email}"
+}
+
 resource "google_cloud_run_v2_service" "this" {
   for_each = local.services
 
@@ -6,7 +42,17 @@ resource "google_cloud_run_v2_service" "this" {
   location = each.value.region
   ingress  = "INGRESS_TRAFFIC_ALL"
 
+  # google_service_account.this[each.key].email is referenced below, but
+  # the grants that make that identity usable aren't - without these, the
+  # deploy can race ahead of the IAM propagation it depends on.
+  depends_on = [
+    google_service_account_iam_member.deployer_can_act_as,
+    google_secret_manager_secret_iam_member.runtime_can_access,
+  ]
+
   template {
+    service_account = google_service_account.this[each.key].email
+
     containers {
       image = "${each.value.values.image.repository}:${each.value.values.image.tag}"
 

--- a/modules/cloudrun-service/main.tf
+++ b/modules/cloudrun-service/main.tf
@@ -12,13 +12,13 @@ resource "google_service_account" "this" {
 
 # Cloud Run V2 requires the deploying principal to be able to act as the
 # identity it assigns to the service, which isn't implied by any role
-# var.deployer holds on the project itself.
+# var.DEPLOYER_SERVICE_ACCOUNT holds on the project itself.
 resource "google_service_account_iam_member" "deployer_can_act_as" {
   for_each = local.services
 
   service_account_id = google_service_account.this[each.key].name
-  role                = "roles/iam.serviceAccountUser"
-  member              = "serviceAccount:${var.deployer}"
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${var.DEPLOYER_SERVICE_ACCOUNT}"
 }
 
 # Grants each service's runtime identity access to read the Secret Manager

--- a/modules/cloudrun-service/values.tf
+++ b/modules/cloudrun-service/values.tf
@@ -170,4 +170,18 @@ locals {
     for f, service in local.services :
     f => service if try(service.values.expose.enabled, false)
   }
+
+  # One IAM grant per (service, secret) pair referenced via env.fromSecrets,
+  # keyed so the same secret referenced by more than one env var on the same
+  # service is only granted once.
+  secret_grants = merge([
+    for f, service in local.services : {
+      for secret in distinct([for ref in values(service.values.env.fromSecrets) : keys(ref)[0]]) :
+      "${f}/${secret}" => {
+        service = f
+        project = service.project
+        secret  = secret
+      }
+    }
+  ]...)
 }

--- a/modules/cloudrun-service/variables.tf
+++ b/modules/cloudrun-service/variables.tf
@@ -38,7 +38,7 @@ variable "domain" {
   default     = ""
 }
 
-variable "deployer" {
+variable "DEPLOYER_SERVICE_ACCOUNT" {
   description = <<-EOT
     Email of the principal running `tofu apply` (e.g. a CI service
     account). Cloud Run V2 requires whoever deploys a service to be able to

--- a/modules/cloudrun-service/variables.tf
+++ b/modules/cloudrun-service/variables.tf
@@ -37,3 +37,14 @@ variable "domain" {
   type        = string
   default     = ""
 }
+
+variable "deployer" {
+  description = <<-EOT
+    Email of the principal running `tofu apply` (e.g. a CI service
+    account). Cloud Run V2 requires whoever deploys a service to be able to
+    act as the identity it runs as, so this is granted
+    roles/iam.serviceAccountUser on every service's dedicated runtime
+    identity (see google_service_account.this in main.tf).
+  EOT
+  type        = string
+}


### PR DESCRIPTION
## Summary
- Creates a dedicated `google_service_account` per Cloud Run service instead of falling back to the project's default Compute Engine SA, which the deploy failed against (403 on `iam.serviceaccounts.actAs`).
- Grants the deploying principal (`var.DEPLOYER_SERVICE_ACCOUNT`, wired from `vars.GOOGLE_SERVICE_ACCOUNT` via `TF_VAR_DEPLOYER_SERVICE_ACCOUNT` in CI) `roles/iam.serviceAccountUser` on that identity, scoped to the resource itself.
- Grants the identity `roles/secretmanager.secretAccessor` on whichever secrets it references via `env.fromSecrets`, so the runtime SA - not the deployer - can actually read them.