### PR TITLE
feat(llm): upgrade vllm to v0.26.0

### DIFF
--- a/charts/llm/Chart.yaml
+++ b/charts/llm/Chart.yaml
@@ -3,5 +3,5 @@ type: application
 name: llm
 description: A Helm chart for deploying a large language model via vLLM on KServe.
 icon: https://img.icons8.com/ios7/1200/electronic-brain.jpg
-version: 0.4.1
-appVersion: "v0.23.0"
+version: 0.4.2
+appVersion: "v0.26.0"


### PR DESCRIPTION
## Summary
- Bump the llm chart's `appVersion` from v0.23.0 to v0.26.0, which sets the `vllm/vllm-openai` image tag used by the ServingRuntime.
- Bump chart `version` from 0.4.1 to 0.4.2.