### PR TITLE
fix(charts): mount dex theme templates file-by-file to avoid ..data crash

### DIFF
--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -3,7 +3,7 @@ type: application
 name: dex
 description: Deploy a Dex instance for single sign-on (SSO) and identity management.
 icon: https://dexidp.io/img/logos/dex-glyph-color.png
-version: 1.0.7
+version: 1.0.8
 appVersion: "0.24.0"
 dependencies:
   - name: dex

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -38,8 +38,45 @@ dex:
     - name: dex-theme-static-img
       mountPath: /web/static/img
       readOnly: true
+    # Mounted file-by-file (subPath) rather than as a whole directory: dex's
+    # template loader does its own fs.ReadDir("templates") to discover files,
+    # and a directory-mounted ConfigMap's "..data" symlink (used for atomic
+    # updates) shows up in that listing and fails to parse as a template.
     - name: dex-theme-templates
-      mountPath: /web/templates
+      mountPath: /web/templates/approval.html
+      subPath: approval.html
+      readOnly: true
+    - name: dex-theme-templates
+      mountPath: /web/templates/device.html
+      subPath: device.html
+      readOnly: true
+    - name: dex-theme-templates
+      mountPath: /web/templates/device_success.html
+      subPath: device_success.html
+      readOnly: true
+    - name: dex-theme-templates
+      mountPath: /web/templates/error.html
+      subPath: error.html
+      readOnly: true
+    - name: dex-theme-templates
+      mountPath: /web/templates/footer.html
+      subPath: footer.html
+      readOnly: true
+    - name: dex-theme-templates
+      mountPath: /web/templates/header.html
+      subPath: header.html
+      readOnly: true
+    - name: dex-theme-templates
+      mountPath: /web/templates/login.html
+      subPath: login.html
+      readOnly: true
+    - name: dex-theme-templates
+      mountPath: /web/templates/oob.html
+      subPath: oob.html
+      readOnly: true
+    - name: dex-theme-templates
+      mountPath: /web/templates/password.html
+      subPath: password.html
       readOnly: true
     - name: dex-theme-kontinuum
       mountPath: /web/themes/kontinuum

--- a/deploy/clusters/prd-cph02/platform/dex.yml
+++ b/deploy/clusters/prd-cph02/platform/dex.yml
@@ -1,3 +1,3 @@
 chart:
   name: dex
-  tag: 1.0.7
+  tag: 1.0.8


### PR DESCRIPTION
## Summary
- Dex failed to start with `failed to load web static: parse files: read templates/..data: is a directory`.
- Root cause: dex's template loader does its own `fs.ReadDir("templates")` to discover files to parse. Mounting the whole ConfigMap as a directory exposes kubelet's `..data` atomic-update symlink in that listing, and dex tries to parse it as a template.
- Fix: mount each of the 9 template files individually via `subPath` instead of mounting the ConfigMap as a whole directory. This bypasses the symlink layout entirely. `static/`, `static/img/`, and `themes/kontinuum/` are unaffected since dex only ever looks those up by exact filename, never lists the directory.
- Bumps chart version to 1.0.8 and the prd-cph02 deploy tag to match.