### PR TITLE
feat(charts): avoid invalid signing keys and stale themes

### DIFF
--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -3,7 +3,7 @@ type: application
 name: dex
 description: Deploy a Dex instance for single sign-on (SSO) and identity management.
 icon: https://dexidp.io/img/logos/dex-glyph-color.png
-version: 1.1.0
+version: 1.1.1
 appVersion: "0.24.0"
 dependencies:
   - name: dex

--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -3,10 +3,10 @@ type: application
 name: dex
 description: Deploy a Dex instance for single sign-on (SSO) and identity management.
 icon: https://dexidp.io/img/logos/dex-glyph-color.png
-version: 1.1.1
-appVersion: "0.24.0"
+version: 1.2.0
+appVersion: "0.24.1"
 dependencies:
   - name: dex
-    version: 0.24.0
+    version: 0.24.1
     repository: "https://charts.dexidp.io"
     condition: dex.enabled

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -1,12 +1,16 @@
 dex:
   enabled: true
-  # Bumped by hand alongside Chart.yaml's version whenever the theme
-  # ConfigMaps (charts/dex/files/web) change. ConfigMap volume contents
-  # update in the running pod on their own, but dex reads its templates
-  # once at startup, so nothing short of a pod restart picks them up -
-  # changing this annotation is what forces that restart.
+  # Mirrors Chart.yaml's version - bump it by hand every time that value
+  # changes. ConfigMap volume contents and other values-driven config
+  # update in the running pod on their own, but dex only reads them once
+  # at startup, so nothing short of a pod restart ever picks them up.
+  # Changing this annotation is what forces that restart.
   podAnnotations:
-    dex.nicklasfrahm.dev/theme-version: "1.1.1"
+    dex.nicklasfrahm.dev/chart-version: "1.2.0"
+  # Rolling out on every chart bump (see podAnnotations above) means old
+  # ReplicaSets pile up faster than the chart's default of 10; 3 is
+  # plenty for rollback purposes here.
+  revisionHistoryLimit: 3
   config:
     logger:
       level: "warn"

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -8,9 +8,9 @@ dex:
   podAnnotations:
     dex.nicklasfrahm.dev/chart-version: "1.2.0"
   # Rolling out on every chart bump (see podAnnotations above) means old
-  # ReplicaSets pile up faster than the chart's default of 10; 3 is
+  # ReplicaSets pile up faster than the chart's default of 10; 5 is
   # plenty for rollback purposes here.
-  revisionHistoryLimit: 3
+  revisionHistoryLimit: 5
   config:
     logger:
       level: "warn"

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -12,7 +12,9 @@ dex:
       level: "warn"
       format: "json"
     storage:
-      type: memory
+      type: kubernetes
+      config:
+        inCluster: true
     frontend:
       dir: /web
       theme: kontinuum

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -1,5 +1,12 @@
 dex:
   enabled: true
+  # Bumped by hand alongside Chart.yaml's version whenever the theme
+  # ConfigMaps (charts/dex/files/web) change. ConfigMap volume contents
+  # update in the running pod on their own, but dex reads its templates
+  # once at startup, so nothing short of a pod restart picks them up -
+  # changing this annotation is what forces that restart.
+  podAnnotations:
+    dex.nicklasfrahm.dev/theme-version: "1.1.1"
   config:
     logger:
       level: "warn"

--- a/deploy/clusters/prd-cph02/platform/dex.yml
+++ b/deploy/clusters/prd-cph02/platform/dex.yml
@@ -1,3 +1,3 @@
 chart:
   name: dex
-  tag: 1.1.0
+  tag: 1.1.1

--- a/deploy/clusters/prd-cph02/platform/dex.yml
+++ b/deploy/clusters/prd-cph02/platform/dex.yml
@@ -1,3 +1,3 @@
 chart:
   name: dex
-  tag: 1.1.1
+  tag: 1.2.0


### PR DESCRIPTION
## Summary
- ConfigMap volume contents update in the running pod on their own (kubelet syncs them within ~a minute), but dex reads its web templates once at startup and never revisits them — so config changes alone never took effect until the pod happened to restart for some unrelated reason.
- The upstream dex chart's Deployment template only exposes `podAnnotations` as a plain value; there's no hook for it to compute a checksum of our own ConfigMaps the way it does for its own config secret (`checksum/config`) — confirmed `tpl` is only applied to the `image.*` fields in its `deployment.yaml`, not `podAnnotations`. So this adds `dex.podAnnotations["dex.nicklasfrahm.dev/chart-version"]`, mirroring `Chart.yaml`'s version and bumped by hand alongside it on every version change — changing a pod annotation forces the rollout the same way `checksum/config` does.
- Updates the vendored dex chart dependency to 0.24.1. This is a chart-only release — `appVersion` (the dex binary) is still v2.44.0 — so the forked web templates need no changes; it just adds native `httpRoute` support (which we already have our own equivalent of) and doc updates. Also fixes `appVersion` to track the chart dependency's own version rather than the dex binary's release tag.
- Switches `storage.type` from `memory` to `kubernetes` (with `inCluster: true`). RBAC for this is already granted by the chart's defaults (`rbac.create` and `rbac.createClusterScoped`, both `true` out of the box) — the existing ClusterRole lets dex create its own `dex.coreos.com` CRDs on first startup. This is a real behavior change: dex's state (auth requests, refresh tokens, etc.) now persists across restarts instead of being wiped every time, as it was with the memory backend — which also means restarting on every chart bump (not just theme changes) is now harmless, hence tying the annotation to the whole chart version rather than scoping it to theme changes specifically.
- Caps `revisionHistoryLimit` at 5 (down from the chart's default of 10), since rolling out more often means old ReplicaSets would otherwise pile up faster.
- Bumps chart version to 1.2.0 and the prd-cph02 deploy tag to match.