### PR TITLE
feat(config): set base KONTINUUM_SERVER_DNS_DOMAIN

### DIFF
--- a/deploy/services/kontinuum/00-base.yml
+++ b/deploy/services/kontinuum/00-base.yml
@@ -31,6 +31,7 @@ expose:
 env:
   fromLiterals:
     KONTINUUM_SERVER_ADDR: ":8080"
+    KONTINUUM_SERVER_DNS_DOMAIN: "nicklasfrahm.dev"
     # OIDC via Dex, public client "kontinuum" (no client secret, PKCE only;
     # see deploy/services/dex/00-base.yml's staticClients entry).
     KONTINUUM_OIDC_ISSUER_URL: "https://auth.nicklasfrahm.dev"


### PR DESCRIPTION
## Summary
- Add `KONTINUUM_SERVER_DNS_DOMAIN=nicklasfrahm.dev` to kontinuum's base config so it's set across all environments