### PR TITLE
fix(ci): skip publish job when discover finds no services

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -85,7 +85,7 @@ jobs:
     needs:
       - release
       - discover
-    if: needs.release.outputs.released == 'true'
+    if: needs.release.outputs.released == 'true' && needs.discover.outputs.matrix != '{"service":[]}'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- The `discover` job produces an empty matrix (`{"service":[]}`) since no service under `cmd/` currently has a `Containerfile` and there's no root fallback either.
- The `publish` job's `strategy.matrix` requires at least one value, so GitHub Actions hard-fails with `Matrix vector 'service' does not contain any values` instead of the job simply being skipped.
- Added a guard to the job's `if` condition so `publish` is skipped when the matrix is empty, rather than failing the whole workflow.

Fixes the failure seen in https://github.com/nicklasfrahm-dev/platform/actions/runs/32099589836