### PR TITLE
fix(config): mount in-memory /tmp volume on kontinuum Cloud Run service

### DIFF
--- a/deploy/services/kontinuum/00-base.yml
+++ b/deploy/services/kontinuum/00-base.yml
@@ -22,8 +22,9 @@ resources:
 # cache when installing addon charts. See
 # https://github.com/nicklasfrahm-dev/kontinuum/issues/103.
 volumes:
-  - name: "scratch"
-    type: "in-memory"
+  scratch:
+    enabled: true
+    type: "Memory"
     mountPath: "/tmp"
 
 autoscaling:

--- a/deploy/services/kontinuum/00-base.yml
+++ b/deploy/services/kontinuum/00-base.yml
@@ -17,6 +17,15 @@ resources:
   cpu: "1"
   memory: "512Mi"
 
+# The container runs with a read-only root filesystem and no writable HOME,
+# but Helm's OCI registry client needs somewhere to write its docker-auth
+# cache when installing addon charts. See
+# https://github.com/nicklasfrahm-dev/kontinuum/issues/103.
+volumes:
+  - name: "scratch"
+    type: "in-memory"
+    mountPath: "/tmp"
+
 autoscaling:
   minReplicas: 0
   maxReplicas: 1

--- a/modules/cloudrun-service/main.tf
+++ b/modules/cloudrun-service/main.tf
@@ -58,16 +58,17 @@ resource "google_cloud_run_v2_service" "this" {
   template {
     service_account = google_service_account.this[each.key].email
 
-    # values.volumes is a list of { name, type, mountPath }. type
-    # "in-memory" is the only kind currently needed (e.g. a writable /tmp
-    # under an otherwise read-only root filesystem) and maps to Cloud Run's
-    # tmpfs-backed empty_dir.
+    # local.enabled_volumes' type follows Kubernetes' EmptyDirVolumeSource
+    # medium enum ("Memory" is the only value Cloud Run's empty_dir volumes
+    # currently support, e.g. for a writable /tmp under an otherwise
+    # read-only root filesystem); upper() translates it to Cloud Run's own
+    # MEMORY medium enum.
     dynamic "volumes" {
-      for_each = try(each.value.values.volumes, [])
+      for_each = local.enabled_volumes[each.key]
       content {
-        name = volumes.value.name
+        name = volumes.key
         empty_dir {
-          medium = "MEMORY"
+          medium = upper(volumes.value.type)
         }
       }
     }
@@ -136,9 +137,9 @@ resource "google_cloud_run_v2_service" "this" {
       }
 
       dynamic "volume_mounts" {
-        for_each = try(each.value.values.volumes, [])
+        for_each = local.enabled_volumes[each.key]
         content {
-          name       = volume_mounts.value.name
+          name       = volume_mounts.key
           mount_path = volume_mounts.value.mountPath
         }
       }

--- a/modules/cloudrun-service/main.tf
+++ b/modules/cloudrun-service/main.tf
@@ -58,6 +58,20 @@ resource "google_cloud_run_v2_service" "this" {
   template {
     service_account = google_service_account.this[each.key].email
 
+    # values.volumes is a list of { name, type, mountPath }. type
+    # "in-memory" is the only kind currently needed (e.g. a writable /tmp
+    # under an otherwise read-only root filesystem) and maps to Cloud Run's
+    # tmpfs-backed empty_dir.
+    dynamic "volumes" {
+      for_each = try(each.value.values.volumes, [])
+      content {
+        name = volumes.value.name
+        empty_dir {
+          medium = "MEMORY"
+        }
+      }
+    }
+
     containers {
       image = "${each.value.values.image.repository}:${each.value.values.image.tag}"
 
@@ -118,6 +132,14 @@ resource "google_cloud_run_v2_service" "this" {
           initial_delay_seconds = liveness_probe.value.initialDelaySeconds
           period_seconds        = liveness_probe.value.periodSeconds
           failure_threshold     = liveness_probe.value.failureThreshold
+        }
+      }
+
+      dynamic "volume_mounts" {
+        for_each = try(each.value.values.volumes, [])
+        content {
+          name       = volume_mounts.value.name
+          mount_path = volume_mounts.value.mountPath
         }
       }
     }

--- a/modules/cloudrun-service/values.tf
+++ b/modules/cloudrun-service/values.tf
@@ -171,6 +171,18 @@ locals {
     f => service if try(service.values.expose.enabled, false)
   }
 
+  # values.volumes is a map keyed by volume name: { enabled, type,
+  # mountPath }. Only enabled entries are kept here so main.tf's
+  # dynamic "volumes"/"volume_mounts" blocks don't need to repeat the
+  # filter.
+  enabled_volumes = {
+    for f, service in local.services :
+    f => {
+      for name, volume in try(service.values.volumes, {}) :
+      name => volume if try(volume.enabled, false)
+    }
+  }
+
   # One IAM grant per (service, secret) pair referenced via env.fromSecrets,
   # keyed so the same secret referenced by more than one env var on the same
   # service is only granted once.


### PR DESCRIPTION
## Summary

- Add `volumes` support to `modules/cloudrun-service` (a `template.volumes` empty_dir block plus matching `container.volume_mounts`), keyed off a new `values.volumes` list of `{ name, type, mountPath }`.
- Mount an in-memory volume at `/tmp` on the kontinuum service in `deploy/services/kontinuum/00-base.yml`.

kontinuum's controller-manager runs on Cloud Run with a read-only root filesystem and no writable `HOME`, so Helm's OCI registry client fails to create its docker-auth cache when installing addon charts. See nicklasfrahm-dev/kontinuum#103 for the full root cause; the app-level half of that fix (pointing Helm's cache dirs at `/tmp`) is being handled separately in the kontinuum repo.