### PR TITLE
fix(config): use gen2 execution environment for Cloud Run in-memory volumes

### DIFF
--- a/modules/cloudrun-service/main.tf
+++ b/modules/cloudrun-service/main.tf
@@ -58,6 +58,11 @@ resource "google_cloud_run_v2_service" "this" {
   template {
     service_account = google_service_account.this[each.key].email
 
+    # In-memory volumes are only supported by Cloud Run's second-generation
+    # execution environment - the default (gen1) accepts this config without
+    # error but the container then never starts.
+    execution_environment = length(local.enabled_volumes[each.key]) > 0 ? "EXECUTION_ENVIRONMENT_GEN2" : null
+
     # local.enabled_volumes' type follows Kubernetes' EmptyDirVolumeSource
     # medium enum ("Memory" is the only value Cloud Run's empty_dir volumes
     # currently support, e.g. for a writable /tmp under an otherwise


### PR DESCRIPTION
## Summary

- Sets `template.execution_environment = EXECUTION_ENVIRONMENT_GEN2` in `modules/cloudrun-service` whenever a service declares any enabled `volumes` entry.

## Why

#383's kontinuum `/tmp` in-memory volume broke [the prd-cloudrun-services apply](https://github.com/nicklasfrahm-dev/platform/actions/runs/32178426522/job/95845631960): the API accepts an in-memory volume under the default (gen1) execution environment without error, but the resulting revision (`kontinuum-00048-6xh`) never bound port 8080 and failed its startup health check — `gcloud run revisions describe` showed no `executionEnvironment` set, and there was zero application-log output across every retry, consistent with gen1 not supporting the mount at runtime. In-memory volumes require gen2. Cloud Run kept serving 100% of traffic on the prior good revision (`kontinuum-00047-gvc`) throughout, so there was no outage — just a failed deploy.