### PR TITLE
feat(llm): upgrade vllm to v0.27.1

### DIFF
--- a/charts/llm/Chart.yaml
+++ b/charts/llm/Chart.yaml
@@ -3,5 +3,5 @@ type: application
 name: llm
 description: A Helm chart for deploying a large language model via vLLM on KServe.
 icon: https://img.icons8.com/ios7/1200/electronic-brain.jpg
-version: 0.4.2
-appVersion: "v0.26.0"
+version: 0.4.3
+appVersion: "v0.27.1"

--- a/charts/llm/values.yaml
+++ b/charts/llm/values.yaml
@@ -30,13 +30,13 @@ model:
         # Memory and performance optimizations.
         - "--quantization=compressed-tensors"
         - "--limit-mm-per-prompt={\"image\": 0, \"video\": 0}"
-        - "--max-model-len=180224"
-        - "--max-num-batched-tokens=8192"
+        - "--max-model-len=131072"
+        - "--max-num-batched-tokens=4096"
         - "--enable-chunked-prefill"
       gpu:
         profile:
           rtx3090-1x:
-            maxNumSeqs: 4
+            maxNumSeqs: 8
             gpuMemoryUtilization: 0.985
             tensorParallelSize: 1
             resources: &rtx3090-1x-resources


### PR DESCRIPTION
Upgrade the llm chart to vLLM v0.27.1 and retune the gemma4-26b default profile (lower max-model-len and max-num-batched-tokens, higher maxNumSeqs). Bumps chart version to 0.4.3.